### PR TITLE
Helm chart - Support AWS creds as secret

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: ack-sns-controller
 description: A Helm chart for the ACK service controller for sns
-version: v0.0.2
-appVersion: v0.0.2
+version: v0.0.3
+appVersion: v0.0.3
 home: https://github.com/aws/aws-controllers-k8s
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -58,4 +58,22 @@ spec:
               fieldPath: metadata.namespace
         - name: AWS_REGION
           value: {{ .Values.aws.region }}
+        - name: AWS_ENDPOINT_URL
+          value: {{ .Values.aws.endpoint_url | quote }}
+        {{- if .Values.aws.credentials.secretName }}
+        - name: AWS_SHARED_CREDENTIALS_FILE
+          value: {{ include "aws.credentials.path" . }}
+        - name: AWS_PROFILE
+          value: {{ .Values.aws.credentials.profile }}
+        volumeMounts:
+          - name: {{ .Values.aws.credentials.secretName }}
+            mountPath: {{ include "aws.credentials.secret_mount_path" . }}
+            readOnly: true
+        {{- end }}
       terminationGracePeriodSeconds: 10
+     {{ if .Values.aws.credentials.secretName -}}
+      volumes:
+        - name: {{ .Values.aws.credentials.secretName }}
+          secret:
+            secretName: {{ .Values.aws.credentials.secretName }}
+      {{ end -}}

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -27,6 +27,14 @@ resources:
 aws:
   # If specified, use the AWS region for AWS API calls
   region: ""
+  endpoint_url: ""
+  credentials:
+    # If specified, Secret with shared credentials file to use.
+    secretName: ""
+    # Secret stringData key that contains the credentials
+    secretKey: "credentials"
+    # Profile used for AWS credentials
+    profile: "default"
 
 serviceAccount:
   # Specifies whether a service account should be created


### PR DESCRIPTION
Issue #, if available:

Description of changes: Like the rest of the AWS ACK controllers, this adds support to the helm chart for providing the AWS credentials as helm chart values.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
