### PR TITLE
release artifacts for v0.0.4

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,59 +1,85 @@
 # Contributing Guidelines
 
-Thank you for your interest in contributing to our project. Whether it's a bug report, new feature, correction, or additional
-documentation, we greatly value feedback and contributions from our community.
+Thank you for your interest in contributing to our project. Whether it's a bug
+report, new feature, correction, or additional documentation, we greatly value
+feedback and contributions from our community.
 
-Please read through this document before submitting any issues or pull requests to ensure we have all the necessary
-information to effectively respond to your bug report or contribution.
-
+Please read through this document before submitting any issues or pull requests
+to ensure we have all the necessary information to effectively respond to your
+bug report or contribution.
 
 ## Reporting Bugs/Feature Requests
 
-We welcome you to use the GitHub issue tracker to report bugs or suggest features.
+We welcome you to use the GitHub issue tracker to report bugs or suggest
+features.
 
-When filing an issue, please check existing open, or recently closed, issues to make sure somebody else hasn't already
-reported the issue. Please try to include as much information as you can. Details like these are incredibly useful:
+When filing an issue, please check existing open, or recently closed, issues to
+make sure somebody else hasn't already reported the issue. Please try to
+include as much information as you can. Details like these are incredibly
+useful:
 
 * A reproducible test case or series of steps
 * The version of our code being used
 * Any modifications you've made relevant to the bug
 * Anything unusual about your environment or deployment
 
-
 ## Contributing via Pull Requests
-Contributions via pull requests are much appreciated. Before sending us a pull request, please ensure that:
+
+Contributions via pull requests are much appreciated. Before sending us a pull
+request, please ensure that:
 
 1. You are working against the latest source on the *main* branch.
-2. You check existing open, and recently merged, pull requests to make sure someone else hasn't addressed the problem already.
-3. You open an issue to discuss any significant work - we would hate for your time to be wasted.
+2. You check existing open, and recently merged, pull requests to make sure
+   someone else hasn't addressed the problem already.
+3. You open an issue to discuss any significant work - we would hate for your
+   time to be wasted.
 
 To send us a pull request, please:
 
 1. Fork the repository.
-2. Modify the source; please focus on the specific change you are contributing. If you also reformat all the code, it will be hard for us to focus on your change.
+2. Modify the source; please focus on the specific change you are contributing.
+   If you also reformat all the code, it will be hard for us to focus on your
+   change.
 3. Ensure local tests pass.
 4. Commit to your fork using clear commit messages.
-5. Send us a pull request, answering any default questions in the pull request interface.
-6. Pay attention to any automated CI failures reported in the pull request, and stay involved in the conversation.
+5. Send us a pull request, answering any default questions in the pull request
+   interface.
+6. Pay attention to any automated CI failures reported in the pull request, and
+   stay involved in the conversation.
 
-GitHub provides additional document on [forking a repository](https://help.github.com/articles/fork-a-repo/) and
-[creating a pull request](https://help.github.com/articles/creating-a-pull-request/).
+GitHub provides additional document on [forking a repository][fork] and
+[creating a pull request][pr].
 
+[fork]: https://help.github.com/articles/fork-a-repo/
+[pr]: https://help.github.com/articles/creating-a-pull-request/
 
 ## Finding contributions to work on
-Looking at the existing issues is a great way to find something to contribute on. As our projects, by default, use the default GitHub issue labels (enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at any 'help wanted' issues is a great place to start.
 
+Looking at the existing issues is a great way to find something to contribute
+on. As our projects, by default, use the default GitHub issue labels
+(enhancement/bug/duplicate/help wanted/invalid/question/wontfix), looking at
+any 'help wanted' issues is a great place to start.
+
+## Developer documentation
+
+[See the documentation][dev-docs] for detailed development information.
+
+[dev-docs]: https://aws-controllers-k8s.github.io/community/docs/contributor-docs/overview/
 
 ## Code of Conduct
-This project has adopted the [Amazon Open Source Code of Conduct](https://aws.github.io/code-of-conduct).
-For more information see the [Code of Conduct FAQ](https://aws.github.io/code-of-conduct-faq) or contact
-opensource-codeofconduct@amazon.com with any additional questions or comments.
 
+We adhere to the [Amazon Open Source Code of Conduct][coc].
+
+[coc]: https://aws.github.io/code-of-conduct
 
 ## Security issue notifications
-If you discover a potential security issue in this project we ask that you notify AWS/Amazon Security via our [vulnerability reporting page](http://aws.amazon.com/security/vulnerability-reporting/). Please do **not** create a public github issue.
 
+If you discover a potential security issue in this project we ask that you
+notify AWS/Amazon Security via our [vulnerability reporting page][vuln]. Please
+do **not** create a public Github issue.
 
-## Licensing
+[vuln]: http://aws.amazon.com/security/vulnerability-reporting/
 
-See the [LICENSE](/LICENSE) file for our project's licensing. We will ask you to confirm the licensing of your contribution.
+## License
+
+This project is [licensed][./LICENSE] under the Apache-2.0 License.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -1,18 +1,30 @@
 # Project governance
 
-This document lays out the guidelines under which the AWS Controllers for Kubernetes (ACK) project will be governed.
+This document lays out the guidelines under which the AWS Controllers for Kubernetes (ACK) project will be governed. 
 The goal is to make sure that the roles and responsibilities are well defined and clarify on how decisions are made.
+
+## Roles
+
+In the context of ACK, we consider the following roles:
+
+* __Users__ ... everyone using ACK, typically willing to provide feedback on ACK by proposing features and/or filing issues.
+* __Contributors__ ... everyone contributing code, documentation, examples, testing infra, and participating in feature proposals as well as design discussions. Code contributions will require a Developer Certificate of Origin (DCO).
+*	__Maintainers__ ... are responsible for engaging with and assisting contributors to iterate on the contributions until it reaches acceptable quality. Maintainers can decide whether the contributions can be accepted into the project or rejected. Any active contributor meeting the project quality can be made a Maintainer by the Advisory Board.
+*	__Advisory Board__ ... is responsible for defining the guidelines and processes that the project operates under. 
+
+The initial members of the Advisory Board are `@jaypipes` and `@mhausenblas`.
+
 
 ## Communication
 
-The primary mechanism for communication will be via the `#provider-aws` channel on the Kubernetes Slack community.
+The primary mechanism for communication will be via the `#provider-aws` channel on the Kubernetes Slack community. 
 All features and bug fixes will be tracked as issues in GitHub. All decisions will be documented in GitHub issues.
 
-In the future, we may consider using a public mailing list, which can be better archived.
+In the future, we may consider using a public mailing list, which can be better archived. 
 
 ## Roadmap Planning
 
-Maintainers will share roadmap and release versions as milestones in GitHub.
+Maintainers will share roadmap and release versions as milestones in GitHub. 
 
 ## Release Management
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,1 @@
-Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
-
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.

--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2022-12-13T18:11:00Z"
-  build_hash: 4aeb2feebfb87ad9c79fcdf02997355de66e228d
+  build_date: "2022-12-16T20:24:15Z"
+  build_hash: e661ce95afc39b380653ca655503daebf1e1831b
   go_version: go1.18.1
-  version: v0.21.0-6-g4aeb2fe
+  version: v0.21.0-5-ge661ce9
 api_directory_checksum: a0c05230761bda067a0f03b794041014296b8bcb
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.93

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/sns-controller
-  newTag: v0.0.0-non-release-version
+  newTag: v0.0.4

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sns-chart
 description: A Helm chart for the ACK service controller for Amazon Simple Notification Service (SNS)
-version: v0.0.0-non-release-version
-appVersion: v0.0.0-non-release-version
+version: v0.0.4
+appVersion: v0.0.4
 home: https://github.com/aws-controllers-k8s/sns-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/sns-controller:v0.0.0-non-release-version".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/sns-controller:v0.0.4".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/sns-controller
-  tag: v0.0.0-non-release-version
+  tag: v0.0.4
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
When running make build-controller, the `scripts/build-controller.sh` script in `github.com/aws-controllers-k8s/code-generator` apparently [copies][0] all of the static files in the code-generator into the target service controller repository. That is why you see the changes to the NOTICE/CONTRIBUTING.md files, etc.

[0]: https://github.com/aws-controllers-k8s/code-generator/blob/e661ce95afc39b380653ca655503daebf1e1831b/scripts/build-controller.sh#L231-L236

Signed-off-by: Jay Pipes <jaypipes@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
