### PR TITLE
Add `Topic` and `PlatformApplication` resource references

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-03-07T21:04:34Z"
-  build_hash: 910a8e0744a99c5c87d8c1615926985215a60d8c
-  go_version: go1.19
-  version: v0.24.3
-api_directory_checksum: 6ee219063f7e4e896fe274ceaa43aae8dba0ff2d
+  build_date: "2023-03-15T01:00:11Z"
+  build_hash: 0888419ec6825035cae1fdee2ceffd7c1ac73ca8
+  go_version: go1.20
+  version: v0.24.3-5-g0888419
+api_directory_checksum: e641c233f2ce8ca688e25316c969dad7b957650b
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.197
 generator_config_info:
-  file_checksum: 7720826fb5187d7dc180ac52b88404dfd34e03d5
+  file_checksum: 70b878367caa7adad624baaf897313c41e3ad847
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -30,8 +30,18 @@ resources:
         is_attribute: true
       Policy:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Policy
+          path: Spec.PolicyDocument
       KmsMasterKeyId:
         is_attribute: true
+        type: string
+        references:
+          service_name: kms
+          resource: Key
+          path: Status.KeyID
       Owner:
         is_attribute: true
         is_read_only: true
@@ -55,16 +65,38 @@ resources:
         is_attribute: true
       EventEndpointCreated:
         is_attribute: true
+        type: string
+        references:
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
       EventEndpointDeleted:
         is_attribute: true
+        type: string
+        references:
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
       EventEndpointUpdated:
         is_attribute: true
+        type: string
+        references:
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
       EventDeliveryFailure:
         is_attribute: true
       SuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       FailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       SuccessFeedbackSampleRate:
         is_attribute: true
     # TODO(jaypipes): Some SNS resources support tag on create. Support tags

--- a/apis/v1alpha1/platform_application.go
+++ b/apis/v1alpha1/platform_application.go
@@ -24,11 +24,15 @@ import (
 //
 // Platform application object.
 type PlatformApplicationSpec struct {
-	EventDeliveryFailure   *string `json:"eventDeliveryFailure,omitempty"`
-	EventEndpointCreated   *string `json:"eventEndpointCreated,omitempty"`
-	EventEndpointDeleted   *string `json:"eventEndpointDeleted,omitempty"`
-	EventEndpointUpdated   *string `json:"eventEndpointUpdated,omitempty"`
-	FailureFeedbackRoleARN *string `json:"failureFeedbackRoleARN,omitempty"`
+	EventDeliveryFailure    *string                                  `json:"eventDeliveryFailure,omitempty"`
+	EventEndpointCreated    *string                                  `json:"eventEndpointCreated,omitempty"`
+	EventEndpointCreatedRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"eventEndpointCreatedRef,omitempty"`
+	EventEndpointDeleted    *string                                  `json:"eventEndpointDeleted,omitempty"`
+	EventEndpointDeletedRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"eventEndpointDeletedRef,omitempty"`
+	EventEndpointUpdated    *string                                  `json:"eventEndpointUpdated,omitempty"`
+	EventEndpointUpdatedRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"eventEndpointUpdatedRef,omitempty"`
+	FailureFeedbackRoleARN  *string                                  `json:"failureFeedbackRoleARN,omitempty"`
+	FailureFeedbackRoleRef  *ackv1alpha1.AWSResourceReferenceWrapper `json:"failureFeedbackRoleRef,omitempty"`
 	// Application names must be made up of only uppercase and lowercase ASCII letters,
 	// numbers, underscores, hyphens, and periods, and must be between 1 and 256
 	// characters long.
@@ -38,11 +42,12 @@ type PlatformApplicationSpec struct {
 	// (Apple Push Notification Service), APNS_SANDBOX, and GCM (Firebase Cloud
 	// Messaging).
 	// +kubebuilder:validation:Required
-	Platform                  *string `json:"platform"`
-	PlatformCredential        *string `json:"platformCredential,omitempty"`
-	PlatformPrincipal         *string `json:"platformPrincipal,omitempty"`
-	SuccessFeedbackRoleARN    *string `json:"successFeedbackRoleARN,omitempty"`
-	SuccessFeedbackSampleRate *string `json:"successFeedbackSampleRate,omitempty"`
+	Platform                  *string                                  `json:"platform"`
+	PlatformCredential        *string                                  `json:"platformCredential,omitempty"`
+	PlatformPrincipal         *string                                  `json:"platformPrincipal,omitempty"`
+	SuccessFeedbackRoleARN    *string                                  `json:"successFeedbackRoleARN,omitempty"`
+	SuccessFeedbackRoleRef    *ackv1alpha1.AWSResourceReferenceWrapper `json:"successFeedbackRoleRef,omitempty"`
+	SuccessFeedbackSampleRate *string                                  `json:"successFeedbackSampleRate,omitempty"`
 }
 
 // PlatformApplicationStatus defines the observed state of PlatformApplication

--- a/apis/v1alpha1/topic.go
+++ b/apis/v1alpha1/topic.go
@@ -33,11 +33,12 @@ type TopicSpec struct {
 	// The policy must be in JSON string format.
 	//
 	// Length Constraints: Maximum length of 30,720.
-	DataProtectionPolicy *string `json:"dataProtectionPolicy,omitempty"`
-	DeliveryPolicy       *string `json:"deliveryPolicy,omitempty"`
-	DisplayName          *string `json:"displayName,omitempty"`
-	FIFOTopic            *string `json:"fifoTopic,omitempty"`
-	KMSMasterKeyID       *string `json:"kmsMasterKeyID,omitempty"`
+	DataProtectionPolicy *string                                  `json:"dataProtectionPolicy,omitempty"`
+	DeliveryPolicy       *string                                  `json:"deliveryPolicy,omitempty"`
+	DisplayName          *string                                  `json:"displayName,omitempty"`
+	FIFOTopic            *string                                  `json:"fifoTopic,omitempty"`
+	KMSMasterKeyID       *string                                  `json:"kmsMasterKeyID,omitempty"`
+	KMSMasterKeyRef      *ackv1alpha1.AWSResourceReferenceWrapper `json:"kmsMasterKeyRef,omitempty"`
 	// The name of the topic you want to create.
 	//
 	// Constraints: Topic names must be made up of only uppercase and lowercase
@@ -46,8 +47,9 @@ type TopicSpec struct {
 	//
 	// For a FIFO (first-in-first-out) topic, the name must end with the .fifo suffix.
 	// +kubebuilder:validation:Required
-	Name   *string `json:"name"`
-	Policy *string `json:"policy,omitempty"`
+	Name      *string                                  `json:"name"`
+	Policy    *string                                  `json:"policy,omitempty"`
+	PolicyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"policyRef,omitempty"`
 	// The list of tags to add to a new topic.
 	//
 	// To be able to tag a topic on creation, you must have the sns:CreateTopic

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -212,20 +212,40 @@ func (in *PlatformApplicationSpec) DeepCopyInto(out *PlatformApplicationSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.EventEndpointCreatedRef != nil {
+		in, out := &in.EventEndpointCreatedRef, &out.EventEndpointCreatedRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EventEndpointDeleted != nil {
 		in, out := &in.EventEndpointDeleted, &out.EventEndpointDeleted
 		*out = new(string)
 		**out = **in
+	}
+	if in.EventEndpointDeletedRef != nil {
+		in, out := &in.EventEndpointDeletedRef, &out.EventEndpointDeletedRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.EventEndpointUpdated != nil {
 		in, out := &in.EventEndpointUpdated, &out.EventEndpointUpdated
 		*out = new(string)
 		**out = **in
 	}
+	if in.EventEndpointUpdatedRef != nil {
+		in, out := &in.EventEndpointUpdatedRef, &out.EventEndpointUpdatedRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.FailureFeedbackRoleARN != nil {
 		in, out := &in.FailureFeedbackRoleARN, &out.FailureFeedbackRoleARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.FailureFeedbackRoleRef != nil {
+		in, out := &in.FailureFeedbackRoleRef, &out.FailureFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
@@ -251,6 +271,11 @@ func (in *PlatformApplicationSpec) DeepCopyInto(out *PlatformApplicationSpec) {
 		in, out := &in.SuccessFeedbackRoleARN, &out.SuccessFeedbackRoleARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.SuccessFeedbackRoleRef != nil {
+		in, out := &in.SuccessFeedbackRoleRef, &out.SuccessFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SuccessFeedbackSampleRate != nil {
 		in, out := &in.SuccessFeedbackSampleRate, &out.SuccessFeedbackSampleRate
@@ -657,6 +682,11 @@ func (in *TopicSpec) DeepCopyInto(out *TopicSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.KMSMasterKeyRef != nil {
+		in, out := &in.KMSMasterKeyRef, &out.KMSMasterKeyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.Name != nil {
 		in, out := &in.Name, &out.Name
 		*out = new(string)
@@ -666,6 +696,11 @@ func (in *TopicSpec) DeepCopyInto(out *TopicSpec) {
 		in, out := &in.Policy, &out.Policy
 		*out = new(string)
 		**out = **in
+	}
+	if in.PolicyRef != nil {
+		in, out := &in.PolicyRef, &out.PolicyRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags

--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -18,6 +18,8 @@ package main
 import (
 	"os"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
+	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcfg "github.com/aws-controllers-k8s/runtime/pkg/config"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -54,6 +56,8 @@ func init() {
 
 	_ = svctypes.AddToScheme(scheme)
 	_ = ackv1alpha1.AddToScheme(scheme)
+	_ = iamapitypes.AddToScheme(scheme)
+	_ = kmsapitypes.AddToScheme(scheme)
 }
 
 func main() {

--- a/config/crd/bases/sns.services.k8s.aws_platformapplications.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_platformapplications.yaml
@@ -41,12 +41,64 @@ spec:
                 type: string
               eventEndpointCreated:
                 type: string
+              eventEndpointCreatedRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               eventEndpointDeleted:
                 type: string
+              eventEndpointDeletedRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               eventEndpointUpdated:
                 type: string
+              eventEndpointUpdatedRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               failureFeedbackRoleARN:
                 type: string
+              failureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: Application names must be made up of only uppercase and
                   lowercase ASCII letters, numbers, underscores, hyphens, and periods,
@@ -63,6 +115,19 @@ spec:
                 type: string
               successFeedbackRoleARN:
                 type: string
+              successFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               successFeedbackSampleRate:
                 type: string
             required:

--- a/config/crd/bases/sns.services.k8s.aws_topics.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_topics.yaml
@@ -53,6 +53,19 @@ spec:
                 type: string
               kmsMasterKeyID:
                 type: string
+              kmsMasterKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: "The name of the topic you want to create. \n Constraints:
                   Topic names must be made up of only uppercase and lowercase ASCII
@@ -62,6 +75,19 @@ spec:
                 type: string
               policy:
                 type: string
+              policyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: "The list of tags to add to a new topic. \n To be able
                   to tag a topic on creation, you must have the sns:CreateTopic and

--- a/config/rbac/cluster-role-controller.yaml
+++ b/config/rbac/cluster-role-controller.yaml
@@ -32,6 +32,48 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - policies
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - policies/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - services.k8s.aws
   resources:
   - adoptedresources

--- a/generator.yaml
+++ b/generator.yaml
@@ -30,8 +30,18 @@ resources:
         is_attribute: true
       Policy:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Policy
+          path: Spec.PolicyDocument
       KmsMasterKeyId:
         is_attribute: true
+        type: string
+        references:
+          service_name: kms
+          resource: Key
+          path: Status.KeyID
       Owner:
         is_attribute: true
         is_read_only: true
@@ -55,16 +65,38 @@ resources:
         is_attribute: true
       EventEndpointCreated:
         is_attribute: true
+        type: string
+        references:
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
       EventEndpointDeleted:
         is_attribute: true
+        type: string
+        references:
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
       EventEndpointUpdated:
         is_attribute: true
+        type: string
+        references:
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
       EventDeliveryFailure:
         is_attribute: true
       SuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       FailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       SuccessFeedbackSampleRate:
         is_attribute: true
     # TODO(jaypipes): Some SNS resources support tag on create. Support tags

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,8 @@ module github.com/aws-controllers-k8s/sns-controller
 go 1.19
 
 require (
+	github.com/aws-controllers-k8s/iam-controller v1.1.1
+	github.com/aws-controllers-k8s/kms-controller v1.0.2
 	github.com/aws-controllers-k8s/runtime v0.24.1
 	github.com/aws/aws-sdk-go v1.44.197
 	github.com/go-logr/logr v1.2.3

--- a/go.sum
+++ b/go.sum
@@ -38,6 +38,10 @@ github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuy
 github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190717042225-c3de453c63f4/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
 github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
+github.com/aws-controllers-k8s/iam-controller v1.1.1 h1:O6arh7DNlQF26MEKzgA2/kBEtZkkQKQypGYAxozNrjE=
+github.com/aws-controllers-k8s/iam-controller v1.1.1/go.mod h1:2+ARwRpazTq5MErjMz0MpXHhtAzRfNtY56Uj0gvu9vE=
+github.com/aws-controllers-k8s/kms-controller v1.0.2 h1:v8nh/oaX/U6spCwBDaWyem7XXpzoP/MnkJyEjNOZN9s=
+github.com/aws-controllers-k8s/kms-controller v1.0.2/go.mod h1:BeoijsyGjJ9G5VcDjpFdxBW0IxaeKXYX497XmUJiPSQ=
 github.com/aws-controllers-k8s/runtime v0.24.1 h1:vmOWKlo4oPtPxeofRnd/dA49WR5VZSqSxHiSiNTiknY=
 github.com/aws-controllers-k8s/runtime v0.24.1/go.mod h1:jizDzKikL09cueIuA9ZxoZ+4pfn5U7oKW5s/ZAqOA6E=
 github.com/aws/aws-sdk-go v1.44.197 h1:pkg/NZsov9v/CawQWy+qWVzJMIZRQypCtYjUBXFomF8=

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -145,10 +145,7 @@ spec:
                             blockOwnerDeletion:
                               description: If true, AND if the owner has the "foregroundDeletion"
                                 finalizer, then the owner cannot be deleted from the
-                                key-value store until this reference is removed. See
-                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
-                                for how the garbage collector interacts with this
-                                field and enforces the foreground deletion. Defaults
+                                key-value store until this reference is removed. Defaults
                                 to false. To set this field, a user needs "delete"
                                 permission of the owner, otherwise 422 (Unprocessable
                                 Entity) will be returned.

--- a/helm/crds/sns.services.k8s.aws_platformapplications.yaml
+++ b/helm/crds/sns.services.k8s.aws_platformapplications.yaml
@@ -41,12 +41,64 @@ spec:
                 type: string
               eventEndpointCreated:
                 type: string
+              eventEndpointCreatedRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               eventEndpointDeleted:
                 type: string
+              eventEndpointDeletedRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               eventEndpointUpdated:
                 type: string
+              eventEndpointUpdatedRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               failureFeedbackRoleARN:
                 type: string
+              failureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: Application names must be made up of only uppercase and
                   lowercase ASCII letters, numbers, underscores, hyphens, and periods,
@@ -63,6 +115,19 @@ spec:
                 type: string
               successFeedbackRoleARN:
                 type: string
+              successFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               successFeedbackSampleRate:
                 type: string
             required:

--- a/helm/crds/sns.services.k8s.aws_topics.yaml
+++ b/helm/crds/sns.services.k8s.aws_topics.yaml
@@ -53,6 +53,19 @@ spec:
                 type: string
               kmsMasterKeyID:
                 type: string
+              kmsMasterKeyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               name:
                 description: "The name of the topic you want to create. \n Constraints:
                   Topic names must be made up of only uppercase and lowercase ASCII
@@ -62,6 +75,19 @@ spec:
                 type: string
               policy:
                 type: string
+              policyRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference type to provide more user friendly syntax
+                  for references using 'from' field Ex: APIIDRef: \n from: name: my-api"
+                properties:
+                  from:
+                    description: AWSResourceReference provides all the values necessary
+                      to reference another k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                    type: object
+                type: object
               tags:
                 description: "The list of tags to add to a new topic. \n To be able
                   to tag a topic on creation, you must have the sns:CreateTopic and

--- a/helm/templates/cluster-role-controller.yaml
+++ b/helm/templates/cluster-role-controller.yaml
@@ -47,6 +47,48 @@ rules:
   - patch
   - watch
 - apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - policies
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - policies/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - iam.services.k8s.aws
+  resources:
+  - roles/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - kms.services.k8s.aws
+  resources:
+  - keys/status
+  verbs:
+  - get
+  - list
+- apiGroups:
   - services.k8s.aws
   resources:
   - adoptedresources

--- a/pkg/resource/platform_application/delta.go
+++ b/pkg/resource/platform_application/delta.go
@@ -57,12 +57,18 @@ func newResourceDelta(
 			delta.Add("Spec.EventEndpointCreated", a.ko.Spec.EventEndpointCreated, b.ko.Spec.EventEndpointCreated)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.EventEndpointCreatedRef, b.ko.Spec.EventEndpointCreatedRef) {
+		delta.Add("Spec.EventEndpointCreatedRef", a.ko.Spec.EventEndpointCreatedRef, b.ko.Spec.EventEndpointCreatedRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.EventEndpointDeleted, b.ko.Spec.EventEndpointDeleted) {
 		delta.Add("Spec.EventEndpointDeleted", a.ko.Spec.EventEndpointDeleted, b.ko.Spec.EventEndpointDeleted)
 	} else if a.ko.Spec.EventEndpointDeleted != nil && b.ko.Spec.EventEndpointDeleted != nil {
 		if *a.ko.Spec.EventEndpointDeleted != *b.ko.Spec.EventEndpointDeleted {
 			delta.Add("Spec.EventEndpointDeleted", a.ko.Spec.EventEndpointDeleted, b.ko.Spec.EventEndpointDeleted)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.EventEndpointDeletedRef, b.ko.Spec.EventEndpointDeletedRef) {
+		delta.Add("Spec.EventEndpointDeletedRef", a.ko.Spec.EventEndpointDeletedRef, b.ko.Spec.EventEndpointDeletedRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.EventEndpointUpdated, b.ko.Spec.EventEndpointUpdated) {
 		delta.Add("Spec.EventEndpointUpdated", a.ko.Spec.EventEndpointUpdated, b.ko.Spec.EventEndpointUpdated)
@@ -71,12 +77,18 @@ func newResourceDelta(
 			delta.Add("Spec.EventEndpointUpdated", a.ko.Spec.EventEndpointUpdated, b.ko.Spec.EventEndpointUpdated)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.EventEndpointUpdatedRef, b.ko.Spec.EventEndpointUpdatedRef) {
+		delta.Add("Spec.EventEndpointUpdatedRef", a.ko.Spec.EventEndpointUpdatedRef, b.ko.Spec.EventEndpointUpdatedRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.FailureFeedbackRoleARN, b.ko.Spec.FailureFeedbackRoleARN) {
 		delta.Add("Spec.FailureFeedbackRoleARN", a.ko.Spec.FailureFeedbackRoleARN, b.ko.Spec.FailureFeedbackRoleARN)
 	} else if a.ko.Spec.FailureFeedbackRoleARN != nil && b.ko.Spec.FailureFeedbackRoleARN != nil {
 		if *a.ko.Spec.FailureFeedbackRoleARN != *b.ko.Spec.FailureFeedbackRoleARN {
 			delta.Add("Spec.FailureFeedbackRoleARN", a.ko.Spec.FailureFeedbackRoleARN, b.ko.Spec.FailureFeedbackRoleARN)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.FailureFeedbackRoleRef, b.ko.Spec.FailureFeedbackRoleRef) {
+		delta.Add("Spec.FailureFeedbackRoleRef", a.ko.Spec.FailureFeedbackRoleRef, b.ko.Spec.FailureFeedbackRoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
@@ -112,6 +124,9 @@ func newResourceDelta(
 		if *a.ko.Spec.SuccessFeedbackRoleARN != *b.ko.Spec.SuccessFeedbackRoleARN {
 			delta.Add("Spec.SuccessFeedbackRoleARN", a.ko.Spec.SuccessFeedbackRoleARN, b.ko.Spec.SuccessFeedbackRoleARN)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.SuccessFeedbackRoleRef, b.ko.Spec.SuccessFeedbackRoleRef) {
+		delta.Add("Spec.SuccessFeedbackRoleRef", a.ko.Spec.SuccessFeedbackRoleRef, b.ko.Spec.SuccessFeedbackRoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SuccessFeedbackSampleRate, b.ko.Spec.SuccessFeedbackSampleRate) {
 		delta.Add("Spec.SuccessFeedbackSampleRate", a.ko.Spec.SuccessFeedbackSampleRate, b.ko.Spec.SuccessFeedbackSampleRate)

--- a/pkg/resource/topic/delta.go
+++ b/pkg/resource/topic/delta.go
@@ -85,6 +85,9 @@ func newResourceDelta(
 			delta.Add("Spec.KMSMasterKeyID", a.ko.Spec.KMSMasterKeyID, b.ko.Spec.KMSMasterKeyID)
 		}
 	}
+	if !reflect.DeepEqual(a.ko.Spec.KMSMasterKeyRef, b.ko.Spec.KMSMasterKeyRef) {
+		delta.Add("Spec.KMSMasterKeyRef", a.ko.Spec.KMSMasterKeyRef, b.ko.Spec.KMSMasterKeyRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Name, b.ko.Spec.Name) {
 		delta.Add("Spec.Name", a.ko.Spec.Name, b.ko.Spec.Name)
 	} else if a.ko.Spec.Name != nil && b.ko.Spec.Name != nil {
@@ -98,6 +101,9 @@ func newResourceDelta(
 		if *a.ko.Spec.Policy != *b.ko.Spec.Policy {
 			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 		}
+	}
+	if !reflect.DeepEqual(a.ko.Spec.PolicyRef, b.ko.Spec.PolicyRef) {
+		delta.Add("Spec.PolicyRef", a.ko.Spec.PolicyRef, b.ko.Spec.PolicyRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TracingConfig, b.ko.Spec.TracingConfig) {
 		delta.Add("Spec.TracingConfig", a.ko.Spec.TracingConfig, b.ko.Spec.TracingConfig)

--- a/pkg/resource/topic/references.go
+++ b/pkg/resource/topic/references.go
@@ -17,12 +17,27 @@ package topic
 
 import (
 	"context"
+	"fmt"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
+	kmsapitypes "github.com/aws-controllers-k8s/kms-controller/apis/v1alpha1"
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1"
 )
+
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
+// +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=policies,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=policies/status,verbs=get;list
 
 // ResolveReferences finds if there are any Reference field(s) present
 // inside AWSResource passed in the parameter and attempts to resolve
@@ -36,17 +51,191 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, error) {
-	return res, nil
+	namespace := res.MetaObject().GetNamespace()
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	err := validateReferenceFields(ko)
+	if err == nil {
+		err = resolveReferenceForKMSMasterKeyID(ctx, apiReader, namespace, ko)
+	}
+	if err == nil {
+		err = resolveReferenceForPolicy(ctx, apiReader, namespace, ko)
+	}
+
+	// If there was an error while resolving any reference, reset all the
+	// resolved values so that they do not get persisted inside etcd
+	if err != nil {
+		ko = rm.concreteResource(res).ko.DeepCopy()
+	}
+	if hasNonNilReferences(ko) {
+		return ackcondition.WithReferencesResolvedCondition(&resource{ko}, err)
+	}
+	return &resource{ko}, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Topic) error {
+	if ko.Spec.KMSMasterKeyRef != nil && ko.Spec.KMSMasterKeyID != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSMasterKeyID", "KMSMasterKeyRef")
+	}
+	if ko.Spec.PolicyRef != nil && ko.Spec.Policy != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("Policy", "PolicyRef")
+	}
 	return nil
 }
 
 // hasNonNilReferences returns true if resource contains a reference to another
 // resource
 func hasNonNilReferences(ko *svcapitypes.Topic) bool {
-	return false
+	return false || (ko.Spec.KMSMasterKeyRef != nil) || (ko.Spec.PolicyRef != nil)
+}
+
+// resolveReferenceForKMSMasterKeyID reads the resource referenced
+// from KMSMasterKeyRef field and sets the KMSMasterKeyID
+// from referenced resource
+func resolveReferenceForKMSMasterKeyID(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Topic,
+) error {
+	if ko.Spec.KMSMasterKeyRef != nil && ko.Spec.KMSMasterKeyRef.From != nil {
+		arr := ko.Spec.KMSMasterKeyRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty: KMSMasterKeyRef")
+		}
+		obj := &kmsapitypes.Key{}
+		if err := getReferencedResourceState_Key(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return err
+		}
+		ko.Spec.KMSMasterKeyID = (*string)(obj.Status.KeyID)
+	}
+
+	return nil
+}
+
+// getReferencedResourceState_Key looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Key(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *kmsapitypes.Key,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Key",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Key",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Key",
+			namespace, name)
+	}
+	if obj.Status.KeyID == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Key",
+			namespace, name,
+			"Status.KeyID")
+	}
+	return nil
+}
+
+// resolveReferenceForPolicy reads the resource referenced
+// from PolicyRef field and sets the Policy
+// from referenced resource
+func resolveReferenceForPolicy(
+	ctx context.Context,
+	apiReader client.Reader,
+	namespace string,
+	ko *svcapitypes.Topic,
+) error {
+	if ko.Spec.PolicyRef != nil && ko.Spec.PolicyRef.From != nil {
+		arr := ko.Spec.PolicyRef.From
+		if arr == nil || arr.Name == nil || *arr.Name == "" {
+			return fmt.Errorf("provided resource reference is nil or empty: PolicyRef")
+		}
+		obj := &iamapitypes.Policy{}
+		if err := getReferencedResourceState_Policy(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return err
+		}
+		ko.Spec.Policy = (*string)(obj.Spec.PolicyDocument)
+	}
+
+	return nil
+}
+
+// getReferencedResourceState_Policy looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Policy(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Policy,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceSynced, refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Policy",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Policy",
+			namespace, name)
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Policy",
+			namespace, name)
+	}
+	if obj.Spec.PolicyDocument == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Policy",
+			namespace, name,
+			"Spec.PolicyDocument")
+	}
+	return nil
 }


### PR DESCRIPTION
Add `Topic` and `PlatformApplication` resource references

This patch brings resource references to Topic and PlatformApplication
resources. There is no way to test this feature unfortunately.

Signed-off-by: Amine Hilaly <hilalyamine@gmail.com>

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
