### PR TITLE
implement set attributes for Topic

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-04-03T16:36:19Z"
+  build_date: "2023-04-03T20:34:28Z"
   build_hash: a6ae2078e57187b2daf47978bc07bd67072d2cba
   go_version: go1.19.4
   version: v0.25.0-1-ga6ae207
-api_directory_checksum: 380fc5d4cda34bde935bb9b5b8838fef498f1d7c
+api_directory_checksum: 6c55185184b615769b57c178e68f021c9e8d4245
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.197
 generator_config_info:
-  file_checksum: ad364bb7662822f237f9b7c1c2815cad52d3f34d
+  file_checksum: 6406ffbe659e8a88e5cecef9d4fef79b0d30285a
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -34,6 +34,8 @@ operations:
     operation_type: SET_ATTRIBUTES
 resources:
   Topic:
+    update_operation:
+      custom_method_name: customUpdate
     unpack_attributes_map:
       set_attributes_single_attribute: true
     exceptions:
@@ -44,8 +46,6 @@ resources:
         code: compareTags(delta, a, b)
       sdk_get_attributes_post_set_output:
         template_path: hooks/topic/sdk_get_attributes_post_set_output.go.tpl
-      sdk_update_pre_build_request:
-        template_path: hooks/topic/sdk_update_pre_build_request.go.tpl
     fields:
       FifoTopic:
         is_attribute: true
@@ -64,6 +64,9 @@ resources:
           service_name: iam
           resource: Policy
           path: Spec.PolicyDocument
+        # The topic policy is apparently automatically set on the server side
+        # if not supplied during create
+        late_initialize: {}
       KmsMasterKeyId:
         is_attribute: true
         type: string
@@ -78,9 +81,8 @@ resources:
       EffectiveDeliveryPolicy:
         is_attribute: true
         is_read_only: true
-      TopicArn:
+      SignatureVersion:
         is_attribute: true
-        is_read_only: true
       Tags:
         compare:
           is_ignored: true

--- a/apis/v1alpha1/platform_endpoint.go
+++ b/apis/v1alpha1/platform_endpoint.go
@@ -28,12 +28,6 @@ type PlatformEndpointSpec struct {
 	// create a an endpoint.
 	// +kubebuilder:validation:Required
 	PlatformApplicationARN *string `json:"platformApplicationARN"`
-	// Unique identifier created by the notification service for an app on a device.
-	// The specific name for Token will vary, depending on which notification service
-	// is being used. For example, when using APNS as the notification service,
-	// you need the device token. Alternatively, when using GCM (Firebase Cloud
-	// Messaging) or ADM, the device token equivalent is called the registration
-	// ID.
 	// +kubebuilder:validation:Required
 	Token *string `json:"token"`
 }

--- a/apis/v1alpha1/topic.go
+++ b/apis/v1alpha1/topic.go
@@ -47,9 +47,10 @@ type TopicSpec struct {
 	//
 	// For a FIFO (first-in-first-out) topic, the name must end with the .fifo suffix.
 	// +kubebuilder:validation:Required
-	Name      *string                                  `json:"name"`
-	Policy    *string                                  `json:"policy,omitempty"`
-	PolicyRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"policyRef,omitempty"`
+	Name             *string                                  `json:"name"`
+	Policy           *string                                  `json:"policy,omitempty"`
+	PolicyRef        *ackv1alpha1.AWSResourceReferenceWrapper `json:"policyRef,omitempty"`
+	SignatureVersion *string                                  `json:"signatureVersion,omitempty"`
 	// The list of tags to add to a new topic.
 	//
 	// To be able to tag a topic on creation, you must have the sns:CreateTopic

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -892,6 +892,11 @@ func (in *TopicSpec) DeepCopyInto(out *TopicSpec) {
 		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.SignatureVersion != nil {
+		in, out := &in.SignatureVersion, &out.SignatureVersion
+		*out = new(string)
+		**out = **in
+	}
 	if in.Tags != nil {
 		in, out := &in.Tags, &out.Tags
 		*out = make([]*Tag, len(*in))

--- a/config/crd/bases/sns.services.k8s.aws_platformendpoints.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_platformendpoints.yaml
@@ -44,12 +44,6 @@ spec:
                   is used to create a an endpoint.
                 type: string
               token:
-                description: Unique identifier created by the notification service
-                  for an app on a device. The specific name for Token will vary, depending
-                  on which notification service is being used. For example, when using
-                  APNS as the notification service, you need the device token. Alternatively,
-                  when using GCM (Firebase Cloud Messaging) or ADM, the device token
-                  equivalent is called the registration ID.
                 type: string
             required:
             - platformApplicationARN

--- a/config/crd/bases/sns.services.k8s.aws_topics.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_topics.yaml
@@ -88,6 +88,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              signatureVersion:
+                type: string
               tags:
                 description: "The list of tags to add to a new topic. \n To be able
                   to tag a topic on creation, you must have the sns:CreateTopic and

--- a/generator.yaml
+++ b/generator.yaml
@@ -34,6 +34,8 @@ operations:
     operation_type: SET_ATTRIBUTES
 resources:
   Topic:
+    update_operation:
+      custom_method_name: customUpdate
     unpack_attributes_map:
       set_attributes_single_attribute: true
     exceptions:
@@ -44,8 +46,6 @@ resources:
         code: compareTags(delta, a, b)
       sdk_get_attributes_post_set_output:
         template_path: hooks/topic/sdk_get_attributes_post_set_output.go.tpl
-      sdk_update_pre_build_request:
-        template_path: hooks/topic/sdk_update_pre_build_request.go.tpl
     fields:
       FifoTopic:
         is_attribute: true
@@ -64,6 +64,9 @@ resources:
           service_name: iam
           resource: Policy
           path: Spec.PolicyDocument
+        # The topic policy is apparently automatically set on the server side
+        # if not supplied during create
+        late_initialize: {}
       KmsMasterKeyId:
         is_attribute: true
         type: string
@@ -78,9 +81,8 @@ resources:
       EffectiveDeliveryPolicy:
         is_attribute: true
         is_read_only: true
-      TopicArn:
+      SignatureVersion:
         is_attribute: true
-        is_read_only: true
       Tags:
         compare:
           is_ignored: true

--- a/helm/crds/sns.services.k8s.aws_platformendpoints.yaml
+++ b/helm/crds/sns.services.k8s.aws_platformendpoints.yaml
@@ -44,12 +44,6 @@ spec:
                   is used to create a an endpoint.
                 type: string
               token:
-                description: Unique identifier created by the notification service
-                  for an app on a device. The specific name for Token will vary, depending
-                  on which notification service is being used. For example, when using
-                  APNS as the notification service, you need the device token. Alternatively,
-                  when using GCM (Firebase Cloud Messaging) or ADM, the device token
-                  equivalent is called the registration ID.
                 type: string
             required:
             - platformApplicationARN

--- a/helm/crds/sns.services.k8s.aws_topics.yaml
+++ b/helm/crds/sns.services.k8s.aws_topics.yaml
@@ -88,6 +88,8 @@ spec:
                         type: string
                     type: object
                 type: object
+              signatureVersion:
+                type: string
               tags:
                 description: "The list of tags to add to a new topic. \n To be able
                   to tag a topic on creation, you must have the sns:CreateTopic and

--- a/pkg/resource/topic/delta.go
+++ b/pkg/resource/topic/delta.go
@@ -106,6 +106,13 @@ func newResourceDelta(
 	if !reflect.DeepEqual(a.ko.Spec.PolicyRef, b.ko.Spec.PolicyRef) {
 		delta.Add("Spec.PolicyRef", a.ko.Spec.PolicyRef, b.ko.Spec.PolicyRef)
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.SignatureVersion, b.ko.Spec.SignatureVersion) {
+		delta.Add("Spec.SignatureVersion", a.ko.Spec.SignatureVersion, b.ko.Spec.SignatureVersion)
+	} else if a.ko.Spec.SignatureVersion != nil && b.ko.Spec.SignatureVersion != nil {
+		if *a.ko.Spec.SignatureVersion != *b.ko.Spec.SignatureVersion {
+			delta.Add("Spec.SignatureVersion", a.ko.Spec.SignatureVersion, b.ko.Spec.SignatureVersion)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TracingConfig, b.ko.Spec.TracingConfig) {
 		delta.Add("Spec.TracingConfig", a.ko.Spec.TracingConfig, b.ko.Spec.TracingConfig)
 	} else if a.ko.Spec.TracingConfig != nil && b.ko.Spec.TracingConfig != nil {

--- a/pkg/resource/topic/hooks.go
+++ b/pkg/resource/topic/hooks.go
@@ -17,12 +17,160 @@ import (
 	"context"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	svcsdk "github.com/aws/aws-sdk-go/service/sns"
 
 	svcapitypes "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1"
 	commonutil "github.com/aws-controllers-k8s/sns-controller/pkg/util"
 )
+
+var (
+	// settableAttributesNames is a list of normalized CRD field names that may
+	// be set in a SetTopicAttribute API call
+	settableAttributeNames = []string{
+		"DeliveryPolicy",
+		"DisplayName",
+		"Policy",
+		"TracingConfig",
+		"KMSMasterKeyID",
+		"SignatureVersion",
+		"ContentBasedDeduplication",
+	}
+)
+
+// customUpdate updates topic attributes and tags. We require a custom update
+// method because (unlike other SetAttributes APIs in SNS -- like
+// PlatformApplication and PlatformEndpoint -- for topics, you can only update
+// a single attribute at a time. Yes, even though the name is
+// SetTopicAttributes (plural), you can only update one attribute at a time. :(
+// This is why we can't have nice things.
+func (rm *resourceManager) customUpdate(
+	ctx context.Context,
+	desired *resource,
+	latest *resource,
+	delta *ackcompare.Delta,
+) (*resource, error) {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.customUpdate")
+	defer func() {
+		exit(err)
+	}()
+	if delta.DifferentAt("Spec.Tags") {
+		if err := rm.syncTags(ctx, desired, latest); err != nil {
+			return nil, err
+		}
+	}
+	if !delta.DifferentExcept("Spec.Tags") {
+		return desired, nil
+	}
+
+	// If any required fields in the input shape are missing, AWS resource is
+	// not created yet. And sdkUpdate should never be called if this is the
+	// case, and it's an error in the generated code if it is...
+	if rm.requiredFieldsMissingFromSetAttributesInput(desired) {
+		panic("Required field in SetAttributes input shape missing!")
+	}
+
+	for _, crdFieldName := range settableAttributeNames {
+		if !delta.DifferentAt("Spec." + crdFieldName) {
+			continue
+		}
+		err = rm.setTopicAttribute(ctx, desired, crdFieldName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ko := desired.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+	return &resource{ko}, nil
+}
+
+// requiredFieldsMissingFromSetAtttributesInput returns true if there are any
+// fields for the SetAttributes Input shape that are required by not present in
+// the resource's Spec or Status
+func (rm *resourceManager) requiredFieldsMissingFromSetAttributesInput(
+	r *resource,
+) bool {
+	return (r.ko.Status.ACKResourceMetadata == nil || r.ko.Status.ACKResourceMetadata.ARN == nil)
+
+}
+
+// setTopicAttribute sets a single attribute for a topic.
+func (rm *resourceManager) setTopicAttribute(
+	ctx context.Context,
+	desired *resource,
+	crdFieldName string,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setTopicAttribute")
+	defer func() {
+		exit(err)
+	}()
+	input := rm.newSetAttributesRequestPayload(desired, crdFieldName)
+	attrValue := ""
+	if input.AttributeValue != nil {
+		attrValue = *input.AttributeValue
+	}
+	rlog.Debug(
+		"setting topic attribute",
+		"attr_name", crdFieldName,
+		"attr_value", attrValue,
+	)
+
+	// NOTE(jaypipes): SetAttributes calls return a response but they don't
+	// contain any useful information. Instead, below, we'll be returning a
+	// DeepCopy of the supplied desired state, which should be fine because
+	// that desired state has been constructed from a call to GetAttributes...
+	_, respErr := rm.sdkapi.SetTopicAttributesWithContext(ctx, input)
+	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "SetTopicAttributes", respErr)
+	if respErr != nil {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFound" {
+			// Technically, this means someone deleted the backend resource in
+			// between the time we got a result back from sdkFind() and here...
+			return ackerr.NotFound
+		}
+		return respErr
+	}
+	return nil
+}
+
+// newSetAttributesRequestPayload returns SDK-specific struct for the HTTP
+// request payload of the SetAttributes API call for the resource
+func (rm *resourceManager) newSetAttributesRequestPayload(
+	r *resource,
+	crdFieldName string,
+) *svcsdk.SetTopicAttributesInput {
+	res := &svcsdk.SetTopicAttributesInput{}
+	res.SetTopicArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
+	switch crdFieldName {
+	case "DeliveryPolicy":
+		res.SetAttributeName("DeliveryPolicy")
+		res.AttributeValue = r.ko.Spec.DeliveryPolicy
+	case "DisplayName":
+		res.SetAttributeName("DisplayName")
+		res.AttributeValue = r.ko.Spec.DisplayName
+	case "Policy":
+		res.SetAttributeName("Policy")
+		res.AttributeValue = r.ko.Spec.Policy
+	case "TracingConfig":
+		res.SetAttributeName("TracingConfig")
+		res.AttributeValue = r.ko.Spec.TracingConfig
+	case "KMSMasterKeyID":
+		res.SetAttributeName("KmsMasterKeyId")
+		res.AttributeValue = r.ko.Spec.KMSMasterKeyID
+	case "SignatureVersion":
+		res.SetAttributeName("SignatureVersion")
+		res.AttributeValue = r.ko.Spec.SignatureVersion
+	case "ContentBasedDeduplication":
+		res.SetAttributeName("ContentBasedDeduplication")
+		res.AttributeValue = r.ko.Spec.ContentBasedDeduplication
+	}
+	return res
+}
 
 // compareTags is a custom comparison function for comparing lists of Tag
 // structs where the order of the structs in the list is not important.

--- a/pkg/resource/topic/manager.go
+++ b/pkg/resource/topic/manager.go
@@ -51,7 +51,7 @@ var (
 // +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=topics,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=sns.services.k8s.aws,resources=topics/status,verbs=get;update;patch
 
-var lateInitializeFieldNames = []string{}
+var lateInitializeFieldNames = []string{"Policy"}
 
 // resourceManager is responsible for providing a consistent way to perform
 // CRUD operations in a backend AWS service API for Book custom resources.
@@ -248,6 +248,10 @@ func (rm *resourceManager) LateInitialize(
 func (rm *resourceManager) incompleteLateInitialization(
 	res acktypes.AWSResource,
 ) bool {
+	ko := rm.concreteResource(res).ko.DeepCopy()
+	if ko.Spec.Policy == nil {
+		return true
+	}
 	return false
 }
 
@@ -257,7 +261,12 @@ func (rm *resourceManager) lateInitializeFromReadOneOutput(
 	observed acktypes.AWSResource,
 	latest acktypes.AWSResource,
 ) acktypes.AWSResource {
-	return latest
+	observedKo := rm.concreteResource(observed).ko.DeepCopy()
+	latestKo := rm.concreteResource(latest).ko.DeepCopy()
+	if observedKo.Spec.Policy != nil && latestKo.Spec.Policy == nil {
+		latestKo.Spec.Policy = observedKo.Spec.Policy
+	}
+	return &resource{latestKo}
 }
 
 // IsSynced returns true if the resource is synced.

--- a/test/e2e/tests/test_topic.py
+++ b/test/e2e/tests/test_topic.py
@@ -125,23 +125,22 @@ class TestTopic:
         assert 'DisplayName' in attrs
         assert attrs['DisplayName'] == "a simple topic"
 
-#        new_display_name = "new display name"
-#
-#        # We're now going to modify the DisplayName field of the Role, wait
-#        # some time and verify that the SNS server-side resource shows the new
-#        # value of the field.
-#        updates = {
-#            "spec": {"displayName": new_display_name},
-#        }
-#        k8s.patch_custom_resource(ref, updates)
-#        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-#
-#        latest = topic.get_attributes(topic_name)
-#        assert latest is not None
-#        assert 'Attributes' in latest
-#        assert 'DisplayName' in latest
-#        assert latest['DisplayName'] == new_display_name
-#
+        new_display_name = "new display name"
+
+        # We're now going to modify the DisplayName field of the Topic, wait
+        # some time and verify that the SNS server-side resource shows the new
+        # value of the field.
+        updates = {
+            "spec": {"displayName": new_display_name},
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        latest = topic.get_attributes(topic_arn)
+        assert latest is not None
+        assert 'DisplayName' in latest
+        assert latest['DisplayName'] == new_display_name
+
         # Same update code path check for tags...
         latest_tags = topic.get_tags(topic_arn)
         expect_before_update_tags = [


### PR DESCRIPTION
This PR introduces support for updating a Topic's attributes. Unfortunately, because you can only set a single attribute on a topic at a time, I had to build a custom update method to properly tackle this. While doing this, I also included support for the SignatureVersion attribute as well as late-initializing the Policy attribute which is set to a value automatically by SNS if the user does not provide a value for this field.

Subscription resources follow this same pattern of multiple calls to SetAttributes APIs to set multiple attributes, so I will follow up this commit with another commit that addresses attribute updates for Subscription resources. Strangely (though really, do we actually expect any different at this point...) SNS other resources -- PlatformApplication and PlaformEndpoint -- have single-shot SetAttributes API calls that can set multiple attribute name/value pairs at once. It's just Topic and Subscription that behave this way for some reason... go figure. :shrug:

Issue aws-controllers-k8s/community#507

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
