### PR TITLE
support update code path for Subscription

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-04-03T20:34:28Z"
+  build_date: "2023-04-04T18:27:42Z"
   build_hash: a6ae2078e57187b2daf47978bc07bd67072d2cba
   go_version: go1.19.4
   version: v0.25.0-1-ga6ae207
-api_directory_checksum: 6c55185184b615769b57c178e68f021c9e8d4245
+api_directory_checksum: b14be96ab59442ec6c1665e0c1a14713da9e5f42
 api_version: v1alpha1
 aws_sdk_go_version: v1.44.197
 generator_config_info:
-  file_checksum: 6406ffbe659e8a88e5cecef9d4fef79b0d30285a
+  file_checksum: eb6753cd4cab8dea8412148ed883fca3928ec692
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -130,8 +130,6 @@ resources:
           path: Status.ACKResourceMetadata.ARN
       SuccessFeedbackSampleRate:
         is_attribute: true
-    # TODO(jaypipes): Some SNS resources support tag on create. Support tags
-    # using Tagris APIs after creation in the future.
     tags:
       ignore: true
   PlatformEndpoint:
@@ -144,11 +142,11 @@ resources:
         is_attribute: true
       Token:
         is_attribute: true
-    # TODO(jaypipes): Some SNS resources support tag on create. Support tags
-    # using Tagris APIs after creation in the future.
     tags:
       ignore: true
   Subscription:
+    update_operation:
+      custom_method_name: customUpdate
     unpack_attributes_map:
       set_attributes_single_attribute: true
     exceptions:
@@ -167,6 +165,8 @@ resources:
         is_attribute: true
         is_read_only: true
       FilterPolicy:
+        is_attribute: true
+      FilterPolicyScope:
         is_attribute: true
       Owner:
         is_attribute: true

--- a/apis/v1alpha1/subscription.go
+++ b/apis/v1alpha1/subscription.go
@@ -49,8 +49,9 @@ type SubscriptionSpec struct {
 	//
 	//   - For the firehose protocol, the endpoint is the ARN of an Amazon Kinesis
 	//     Data Firehose delivery stream.
-	Endpoint     *string `json:"endpoint,omitempty"`
-	FilterPolicy *string `json:"filterPolicy,omitempty"`
+	Endpoint          *string `json:"endpoint,omitempty"`
+	FilterPolicy      *string `json:"filterPolicy,omitempty"`
+	FilterPolicyScope *string `json:"filterPolicyScope,omitempty"`
 	// The protocol that you want to use. Supported protocols include:
 	//
 	//   - http – delivery of JSON-encoded message via HTTP POST

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -622,6 +622,11 @@ func (in *SubscriptionSpec) DeepCopyInto(out *SubscriptionSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FilterPolicyScope != nil {
+		in, out := &in.FilterPolicyScope, &out.FilterPolicyScope
+		*out = new(string)
+		**out = **in
+	}
 	if in.Protocol != nil {
 		in, out := &in.Protocol, &out.Protocol
 		*out = new(string)

--- a/config/crd/bases/sns.services.k8s.aws_subscriptions.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_subscriptions.yaml
@@ -55,6 +55,8 @@ spec:
                 type: string
               filterPolicy:
                 type: string
+              filterPolicyScope:
+                type: string
               protocol:
                 description: "The protocol that you want to use. Supported protocols
                   include: \n * http – delivery of JSON-encoded message via HTTP POST

--- a/generator.yaml
+++ b/generator.yaml
@@ -130,8 +130,6 @@ resources:
           path: Status.ACKResourceMetadata.ARN
       SuccessFeedbackSampleRate:
         is_attribute: true
-    # TODO(jaypipes): Some SNS resources support tag on create. Support tags
-    # using Tagris APIs after creation in the future.
     tags:
       ignore: true
   PlatformEndpoint:
@@ -144,11 +142,11 @@ resources:
         is_attribute: true
       Token:
         is_attribute: true
-    # TODO(jaypipes): Some SNS resources support tag on create. Support tags
-    # using Tagris APIs after creation in the future.
     tags:
       ignore: true
   Subscription:
+    update_operation:
+      custom_method_name: customUpdate
     unpack_attributes_map:
       set_attributes_single_attribute: true
     exceptions:
@@ -167,6 +165,8 @@ resources:
         is_attribute: true
         is_read_only: true
       FilterPolicy:
+        is_attribute: true
+      FilterPolicyScope:
         is_attribute: true
       Owner:
         is_attribute: true

--- a/helm/crds/services.k8s.aws_adoptedresources.yaml
+++ b/helm/crds/services.k8s.aws_adoptedresources.yaml
@@ -145,10 +145,7 @@ spec:
                             blockOwnerDeletion:
                               description: If true, AND if the owner has the "foregroundDeletion"
                                 finalizer, then the owner cannot be deleted from the
-                                key-value store until this reference is removed. See
-                                https://kubernetes.io/docs/concepts/architecture/garbage-collection/#foreground-deletion
-                                for how the garbage collector interacts with this
-                                field and enforces the foreground deletion. Defaults
+                                key-value store until this reference is removed. Defaults
                                 to false. To set this field, a user needs "delete"
                                 permission of the owner, otherwise 422 (Unprocessable
                                 Entity) will be returned.

--- a/helm/crds/sns.services.k8s.aws_subscriptions.yaml
+++ b/helm/crds/sns.services.k8s.aws_subscriptions.yaml
@@ -55,6 +55,8 @@ spec:
                 type: string
               filterPolicy:
                 type: string
+              filterPolicyScope:
+                type: string
               protocol:
                 description: "The protocol that you want to use. Supported protocols
                   include: \n - http – delivery of JSON-encoded message via HTTP POST

--- a/pkg/resource/subscription/delta.go
+++ b/pkg/resource/subscription/delta.go
@@ -64,6 +64,13 @@ func newResourceDelta(
 			delta.Add("Spec.FilterPolicy", a.ko.Spec.FilterPolicy, b.ko.Spec.FilterPolicy)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.FilterPolicyScope, b.ko.Spec.FilterPolicyScope) {
+		delta.Add("Spec.FilterPolicyScope", a.ko.Spec.FilterPolicyScope, b.ko.Spec.FilterPolicyScope)
+	} else if a.ko.Spec.FilterPolicyScope != nil && b.ko.Spec.FilterPolicyScope != nil {
+		if *a.ko.Spec.FilterPolicyScope != *b.ko.Spec.FilterPolicyScope {
+			delta.Add("Spec.FilterPolicyScope", a.ko.Spec.FilterPolicyScope, b.ko.Spec.FilterPolicyScope)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Protocol, b.ko.Spec.Protocol) {
 		delta.Add("Spec.Protocol", a.ko.Spec.Protocol, b.ko.Spec.Protocol)
 	} else if a.ko.Spec.Protocol != nil && b.ko.Spec.Protocol != nil {

--- a/pkg/resource/subscription/hooks.go
+++ b/pkg/resource/subscription/hooks.go
@@ -17,14 +17,142 @@ import (
 	"context"
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
+	svcsdk "github.com/aws/aws-sdk-go/service/sns"
 )
 
-// noopUpdate is a placeholder until UPDATE code paths can be implemented
-func (rm *resourceManager) noopUpdate(
+var (
+	// settableAttributesNames is a list of normalized CRD field names that may
+	// be set in a SetSubscriptionAttribute API call
+	settableAttributeNames = []string{
+		"DeliveryPolicy",
+		"FilterPolicy",
+		"FilterPolicyScope",
+		"RawMessageDelivery",
+		"RedrivePolicy",
+		"SubscriptionRoleARN",
+	}
+)
+
+// customUpdate updates subscription attributes and tags. We require a custom
+// update method because (unlike other SetAttributes APIs in SNS -- like
+// PlatformApplication and PlatformEndpoint -- for subscriptions, you can only
+// update a single attribute at a time. Yes, even though the name is
+// SetSubscriptionAttributes (plural), you can only update one attribute at a
+// time. :( This is why we can't have nice things.
+func (rm *resourceManager) customUpdate(
 	ctx context.Context,
 	desired *resource,
 	latest *resource,
 	delta *ackcompare.Delta,
-) (updated *resource, err error) {
-	return desired, nil
+) (*resource, error) {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.customUpdate")
+	defer func() {
+		exit(err)
+	}()
+
+	// If any required fields in the input shape are missing, AWS resource is
+	// not created yet. And sdkUpdate should never be called if this is the
+	// case, and it's an error in the generated code if it is...
+	if rm.requiredFieldsMissingFromSetAttributesInput(desired) {
+		panic("Required field in SetAttributes input shape missing!")
+	}
+
+	for _, crdFieldName := range settableAttributeNames {
+		if !delta.DifferentAt("Spec." + crdFieldName) {
+			continue
+		}
+		err = rm.setSubscriptionAttribute(ctx, desired, crdFieldName)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	ko := desired.ko.DeepCopy()
+	rm.setStatusDefaults(ko)
+	return &resource{ko}, nil
+}
+
+// requiredFieldsMissingFromSetAtttributesInput returns true if there are any
+// fields for the SetAttributes Input shape that are required by not present in
+// the resource's Spec or Status
+func (rm *resourceManager) requiredFieldsMissingFromSetAttributesInput(
+	r *resource,
+) bool {
+	return (r.ko.Status.ACKResourceMetadata == nil || r.ko.Status.ACKResourceMetadata.ARN == nil)
+
+}
+
+// setSubscriptionAttribute sets a single attribute for a subscription.
+func (rm *resourceManager) setSubscriptionAttribute(
+	ctx context.Context,
+	desired *resource,
+	crdFieldName string,
+) error {
+	var err error
+	rlog := ackrtlog.FromContext(ctx)
+	exit := rlog.Trace("rm.setSubscriptionAttribute")
+	defer func() {
+		exit(err)
+	}()
+	input := rm.newSetAttributesRequestPayload(desired, crdFieldName)
+	attrValue := ""
+	if input.AttributeValue != nil {
+		attrValue = *input.AttributeValue
+	}
+	rlog.Debug(
+		"setting subscription attribute",
+		"attr_name", crdFieldName,
+		"attr_value", attrValue,
+	)
+
+	// NOTE(jaypipes): SetAttributes calls return a response but they don't
+	// contain any useful information. Instead, below, we'll be returning a
+	// DeepCopy of the supplied desired state, which should be fine because
+	// that desired state has been constructed from a call to GetAttributes...
+	_, respErr := rm.sdkapi.SetSubscriptionAttributesWithContext(ctx, input)
+	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "SetSubscriptionAttributes", respErr)
+	if respErr != nil {
+		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFound" {
+			// Technically, this means someone deleted the backend resource in
+			// between the time we got a result back from sdkFind() and here...
+			return ackerr.NotFound
+		}
+		return respErr
+	}
+	return nil
+}
+
+// newSetAttributesRequestPayload returns SDK-specific struct for the HTTP
+// request payload of the SetAttributes API call for the resource
+func (rm *resourceManager) newSetAttributesRequestPayload(
+	r *resource,
+	crdFieldName string,
+) *svcsdk.SetSubscriptionAttributesInput {
+	res := &svcsdk.SetSubscriptionAttributesInput{}
+	res.SetSubscriptionArn(string(*r.ko.Status.ACKResourceMetadata.ARN))
+	switch crdFieldName {
+	case "DeliveryPolicy":
+		res.SetAttributeName("DeliveryPolicy")
+		res.AttributeValue = r.ko.Spec.DeliveryPolicy
+	case "FilterPolicy":
+		res.SetAttributeName("FilterPolicy")
+		res.AttributeValue = r.ko.Spec.FilterPolicy
+	case "FilterPolicyScope":
+		res.SetAttributeName("FilterPolicyScope")
+		res.AttributeValue = r.ko.Spec.FilterPolicyScope
+	case "RawMessageDelivery":
+		res.SetAttributeName("RawMessageDelivery")
+		res.AttributeValue = r.ko.Spec.RawMessageDelivery
+	case "RedrivePolicy":
+		res.SetAttributeName("RedrivePolicy")
+		res.AttributeValue = r.ko.Spec.RedrivePolicy
+	case "SubscriptionRoleARN":
+		res.SetAttributeName("SubscriptionRoleArn")
+		res.AttributeValue = r.ko.Spec.SubscriptionRoleARN
+	}
+	return res
 }

--- a/pkg/resource/subscription/sdk.go
+++ b/pkg/resource/subscription/sdk.go
@@ -90,6 +90,7 @@ func (rm *resourceManager) sdkFind(
 	ko.Spec.DeliveryPolicy = resp.Attributes["DeliveryPolicy"]
 	ko.Status.EffectiveDeliveryPolicy = resp.Attributes["EffectiveDeliveryPolicy"]
 	ko.Spec.FilterPolicy = resp.Attributes["FilterPolicy"]
+	ko.Spec.FilterPolicyScope = resp.Attributes["FilterPolicyScope"]
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
@@ -184,6 +185,9 @@ func (rm *resourceManager) newCreateRequestPayload(
 	if r.ko.Spec.FilterPolicy != nil {
 		attrMap["FilterPolicy"] = r.ko.Spec.FilterPolicy
 	}
+	if r.ko.Spec.FilterPolicyScope != nil {
+		attrMap["FilterPolicyScope"] = r.ko.Spec.FilterPolicyScope
+	}
 	if r.ko.Spec.RawMessageDelivery != nil {
 		attrMap["RawMessageDelivery"] = r.ko.Spec.RawMessageDelivery
 	}
@@ -215,64 +219,7 @@ func (rm *resourceManager) sdkUpdate(
 	latest *resource,
 	delta *ackcompare.Delta,
 ) (*resource, error) {
-	var err error
-	rlog := ackrtlog.FromContext(ctx)
-	exit := rlog.Trace("rm.sdkUpdate")
-	defer func() {
-		exit(err)
-	}()
-	// If any required fields in the input shape are missing, AWS resource is
-	// not created yet. And sdkUpdate should never be called if this is the
-	// case, and it's an error in the generated code if it is...
-	if rm.requiredFieldsMissingFromSetAttributesInput(desired) {
-		panic("Required field in SetAttributes input shape missing!")
-	}
-
-	input, err := rm.newSetAttributesRequestPayload(desired)
-	if err != nil {
-		return nil, err
-	}
-
-	// NOTE(jaypipes): SetAttributes calls return a response but they don't
-	// contain any useful information. Instead, below, we'll be returning a
-	// DeepCopy of the supplied desired state, which should be fine because
-	// that desired state has been constructed from a call to GetAttributes...
-	_, respErr := rm.sdkapi.SetSubscriptionAttributesWithContext(ctx, input)
-	rm.metrics.RecordAPICall("SET_ATTRIBUTES", "SetSubscriptionAttributes", respErr)
-	if respErr != nil {
-		if awsErr, ok := ackerr.AWSError(respErr); ok && awsErr.Code() == "NotFound" {
-			// Technically, this means someone deleted the backend resource in
-			// between the time we got a result back from sdkFind() and here...
-			return nil, ackerr.NotFound
-		}
-		return nil, respErr
-	}
-
-	// Merge in the information we read from the API call above to the copy of
-	// the original Kubernetes object we passed to the function
-	ko := desired.ko.DeepCopy()
-	rm.setStatusDefaults(ko)
-	return &resource{ko}, nil
-}
-
-// requiredFieldsMissingFromSetAtttributesInput returns true if there are any
-// fields for the SetAttributes Input shape that are required by not present in
-// the resource's Spec or Status
-func (rm *resourceManager) requiredFieldsMissingFromSetAttributesInput(
-	r *resource,
-) bool {
-	return (r.ko.Status.ACKResourceMetadata == nil || r.ko.Status.ACKResourceMetadata.ARN == nil)
-
-}
-
-// newSetAttributesRequestPayload returns SDK-specific struct for the HTTP
-// request payload of the SetAttributes API call for the resource
-func (rm *resourceManager) newSetAttributesRequestPayload(
-	r *resource,
-) (*svcsdk.SetSubscriptionAttributesInput, error) {
-	res := &svcsdk.SetSubscriptionAttributesInput{}
-
-	return res, nil
+	return rm.customUpdate(ctx, desired, latest, delta)
 }
 
 // sdkDelete deletes the supplied resource in the backend AWS service API


### PR DESCRIPTION
Adds support for updating Subscription resource fields via calls to SetSubscriptionAttributes, which is similar to SetTopicAttributes and requires multiple calls to SetSubscriptionAttributes, once for each changed attribute name/value pair.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
