### PR TITLE
chore: remove reference to owner in sns-controller to fix provisioning on multiple accounts

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2023-12-14T21:59:35Z"
+  build_date: "2023-12-15T22:18:53Z"
   build_hash: 1f16813c807af6889060b4ce7ded2a69dc027d8c
-  go_version: go1.21.5
-  version: v0.28.0
-api_directory_checksum: fb5d87c433b89ccae7f55399f3db96e63943c994
+  go_version: go1.21.4
+  version: v0.27.1-9-g1f16813
+api_directory_checksum: 7c43c51981644a8d71e17546dc282a16d5363364
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: e8c9e140ef5690daab43e5452645acfd993dc678
+  file_checksum: 3012c32be5d56b00b9737ad2b5c7f502bc5aae03
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -85,7 +85,6 @@ resources:
       Owner:
         is_attribute: true
         is_read_only: true
-        is_owner_account_id: true
       EffectiveDeliveryPolicy:
         is_attribute: true
         is_read_only: true
@@ -184,7 +183,6 @@ resources:
       Owner:
         is_attribute: true
         is_read_only: true
-        is_owner_account_id: true
       PendingConfirmation:
         is_attribute: true
         is_read_only: true

--- a/apis/v1alpha1/platform_endpoint.go
+++ b/apis/v1alpha1/platform_endpoint.go
@@ -22,21 +22,12 @@ import (
 
 // PlatformEndpointSpec defines the desired state of PlatformEndpoint.
 type PlatformEndpointSpec struct {
-
-	// Arbitrary user data to associate with the endpoint. Amazon SNS does not use
-	// this data. The data must be in UTF-8 format and less than 2KB.
 	CustomUserData *string `json:"customUserData,omitempty"`
 	Enabled        *string `json:"enabled,omitempty"`
 	// PlatformApplicationArn returned from CreatePlatformApplication is used to
 	// create a an endpoint.
 	// +kubebuilder:validation:Required
 	PlatformApplicationARN *string `json:"platformApplicationARN"`
-	// Unique identifier created by the notification service for an app on a device.
-	// The specific name for Token will vary, depending on which notification service
-	// is being used. For example, when using APNS as the notification service,
-	// you need the device token. Alternatively, when using GCM (Firebase Cloud
-	// Messaging) or ADM, the device token equivalent is called the registration
-	// ID.
 	// +kubebuilder:validation:Required
 	Token *string `json:"token"`
 }

--- a/config/crd/bases/sns.services.k8s.aws_platformendpoints.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_platformendpoints.yaml
@@ -36,9 +36,6 @@ spec:
             description: PlatformEndpointSpec defines the desired state of PlatformEndpoint.
             properties:
               customUserData:
-                description: Arbitrary user data to associate with the endpoint. Amazon
-                  SNS does not use this data. The data must be in UTF-8 format and
-                  less than 2KB.
                 type: string
               enabled:
                 type: string
@@ -47,12 +44,6 @@ spec:
                   is used to create a an endpoint.
                 type: string
               token:
-                description: Unique identifier created by the notification service
-                  for an app on a device. The specific name for Token will vary, depending
-                  on which notification service is being used. For example, when using
-                  APNS as the notification service, you need the device token. Alternatively,
-                  when using GCM (Firebase Cloud Messaging) or ADM, the device token
-                  equivalent is called the registration ID.
                 type: string
             required:
             - platformApplicationARN

--- a/generator.yaml
+++ b/generator.yaml
@@ -85,7 +85,6 @@ resources:
       Owner:
         is_attribute: true
         is_read_only: true
-        is_owner_account_id: true
       EffectiveDeliveryPolicy:
         is_attribute: true
         is_read_only: true
@@ -184,7 +183,6 @@ resources:
       Owner:
         is_attribute: true
         is_read_only: true
-        is_owner_account_id: true
       PendingConfirmation:
         is_attribute: true
         is_read_only: true

--- a/helm/crds/sns.services.k8s.aws_platformendpoints.yaml
+++ b/helm/crds/sns.services.k8s.aws_platformendpoints.yaml
@@ -36,9 +36,6 @@ spec:
             description: PlatformEndpointSpec defines the desired state of PlatformEndpoint.
             properties:
               customUserData:
-                description: Arbitrary user data to associate with the endpoint. Amazon
-                  SNS does not use this data. The data must be in UTF-8 format and
-                  less than 2KB.
                 type: string
               enabled:
                 type: string
@@ -47,12 +44,6 @@ spec:
                   is used to create a an endpoint.
                 type: string
               token:
-                description: Unique identifier created by the notification service
-                  for an app on a device. The specific name for Token will vary, depending
-                  on which notification service is being used. For example, when using
-                  APNS as the notification service, you need the device token. Alternatively,
-                  when using GCM (Firebase Cloud Messaging) or ADM, the device token
-                  equivalent is called the registration ID.
                 type: string
             required:
             - platformApplicationARN

--- a/pkg/resource/subscription/sdk.go
+++ b/pkg/resource/subscription/sdk.go
@@ -91,11 +91,7 @@ func (rm *resourceManager) sdkFind(
 	ko.Status.EffectiveDeliveryPolicy = resp.Attributes["EffectiveDeliveryPolicy"]
 	ko.Spec.FilterPolicy = resp.Attributes["FilterPolicy"]
 	ko.Spec.FilterPolicyScope = resp.Attributes["FilterPolicyScope"]
-	if ko.Status.ACKResourceMetadata == nil {
-		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
-	}
-	tmpOwnerID := ackv1alpha1.AWSAccountID(*resp.Attributes["Owner"])
-	ko.Status.ACKResourceMetadata.OwnerAccountID = &tmpOwnerID
+	ko.Status.Owner = resp.Attributes["Owner"]
 	ko.Status.PendingConfirmation = resp.Attributes["PendingConfirmation"]
 	ko.Spec.RawMessageDelivery = resp.Attributes["RawMessageDelivery"]
 	ko.Spec.RedrivePolicy = resp.Attributes["RedrivePolicy"]

--- a/pkg/resource/topic/sdk.go
+++ b/pkg/resource/topic/sdk.go
@@ -92,13 +92,12 @@ func (rm *resourceManager) sdkFind(
 	ko.Status.EffectiveDeliveryPolicy = resp.Attributes["EffectiveDeliveryPolicy"]
 	ko.Spec.FIFOTopic = resp.Attributes["FifoTopic"]
 	ko.Spec.KMSMasterKeyID = resp.Attributes["KmsMasterKeyId"]
+	ko.Status.Owner = resp.Attributes["Owner"]
+	ko.Spec.Policy = resp.Attributes["Policy"]
+	ko.Spec.SignatureVersion = resp.Attributes["SignatureVersion"]
 	if ko.Status.ACKResourceMetadata == nil {
 		ko.Status.ACKResourceMetadata = &ackv1alpha1.ResourceMetadata{}
 	}
-	tmpOwnerID := ackv1alpha1.AWSAccountID(*resp.Attributes["Owner"])
-	ko.Status.ACKResourceMetadata.OwnerAccountID = &tmpOwnerID
-	ko.Spec.Policy = resp.Attributes["Policy"]
-	ko.Spec.SignatureVersion = resp.Attributes["SignatureVersion"]
 	tmpARN := ackv1alpha1.AWSResourceName(*resp.Attributes["TopicArn"])
 	ko.Status.ACKResourceMetadata.ARN = &tmpARN
 	ko.Spec.TracingConfig = resp.Attributes["TracingConfig"]


### PR DESCRIPTION
Description of changes:

The previous setup would override the value in the configmap, making it so that any reconciliation after the first creation fails if the account does not match the key used in the auth configmap.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
