### PR TITLE
fix(subscription): handle nil `RawMessageDelivery` in delta comparison

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-10-10T04:06:54Z"
+  build_date: "2024-10-24T02:01:48Z"
   build_hash: 36c2d234498c2bc4f60773ab8df632af4067f43b
   go_version: go1.23.2
   version: v0.39.1
-api_directory_checksum: bcc8c2cf96b31122dc6ff2654d065e3bbd8f0c33
+api_directory_checksum: ca04ac625e016be719b2899d653c5c11451ccb40
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: e8c9e140ef5690daab43e5452645acfd993dc678
+  file_checksum: d3bd4b1ffa6fe007058950b96d686a4b344b3b8d
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -168,6 +168,8 @@ resources:
         template_path: hooks/subscription/sdk_create_post_build_request.go.tpl
       sdk_get_attributes_pre_set_output:
         template_path: hooks/subscription/sdk_get_attributes_pre_set_output.go.tpl
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
     fields:
       ConfirmationWasAuthenticated:
         is_attribute: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -168,6 +168,8 @@ resources:
         template_path: hooks/subscription/sdk_create_post_build_request.go.tpl
       sdk_get_attributes_pre_set_output:
         template_path: hooks/subscription/sdk_get_attributes_pre_set_output.go.tpl
+      delta_pre_compare:
+        code: customPreCompare(delta, a, b)
     fields:
       ConfirmationWasAuthenticated:
         is_attribute: true

--- a/pkg/resource/subscription/delta.go
+++ b/pkg/resource/subscription/delta.go
@@ -42,6 +42,7 @@ func newResourceDelta(
 		delta.Add("", a, b)
 		return delta
 	}
+	customPreCompare(delta, a, b)
 
 	if ackcompare.HasNilDifference(a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy) {
 		delta.Add("Spec.DeliveryPolicy", a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy)

--- a/pkg/resource/subscription/hooks.go
+++ b/pkg/resource/subscription/hooks.go
@@ -156,3 +156,9 @@ func (rm *resourceManager) newSetAttributesRequestPayload(
 	}
 	return res
 }
+
+func customPreCompare(delta *ackcompare.Delta, a, b *resource) {
+	if a.ko.Spec.RawMessageDelivery == nil {
+		a.ko.Spec.RawMessageDelivery = b.ko.Spec.RawMessageDelivery
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2195

The change adds a custom pre comparison hook for the Subscription resource
to handle cases where `RawMessageDelivery` is nil in the source object. This
prevents unnecessary updates when only the `RawMessageDelivery` field differs
in nil/non-nil status but represents the same effective configuration.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
