### PR TITLE
feat(crds): add printer columns for `Topic` and `Subscription`

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2024-10-10T04:06:54Z"
+  build_date: "2024-10-24T02:09:19Z"
   build_hash: 36c2d234498c2bc4f60773ab8df632af4067f43b
   go_version: go1.23.2
   version: v0.39.1
-api_directory_checksum: bcc8c2cf96b31122dc6ff2654d065e3bbd8f0c33
+api_directory_checksum: 07a2ec03f194442b69cf147a88a4cc33badaa895
 api_version: v1alpha1
 aws_sdk_go_version: v1.49.0
 generator_config_info:
-  file_checksum: e8c9e140ef5690daab43e5452645acfd993dc678
+  file_checksum: e95b5fd9a0571826102c9546eae4cc73228a8395
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -34,6 +34,18 @@ operations:
     operation_type: SET_ATTRIBUTES
 resources:
   Topic:
+    print:
+      add_age_column: true
+      add_synced_column: true
+      additional_columns:
+        - name: ARN
+          json_path: .status.ackResourceMetadata.arn
+          type: string
+          priority: 1 # shows only in -o view
+        - name: DISPLAYNAME
+          json_path: .spec.displayName
+          type: string
+          priority: 0
     is_arn_primary_key: true
     update_operation:
       custom_method_name: customUpdate
@@ -155,6 +167,14 @@ resources:
     tags:
       ignore: true
   Subscription:
+    print:
+      add_age_column: true
+      add_synced_column: true
+      additional_columns:
+        - name: ARN
+          json_path: .status.ackResourceMetadata.arn
+          type: string
+          priority: 1 # shows only in -o view
     is_arn_primary_key: true
     update_operation:
       custom_method_name: customUpdate

--- a/apis/v1alpha1/subscription.go
+++ b/apis/v1alpha1/subscription.go
@@ -110,6 +110,9 @@ type SubscriptionStatus struct {
 // Subscription is the Schema for the Subscriptions API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ARN",type=string,priority=1,JSONPath=`.status.ackResourceMetadata.arn`
+// +kubebuilder:printcolumn:name="Synced",type="string",priority=0,JSONPath=".status.conditions[?(@.type==\"ACK.ResourceSynced\")].status"
+// +kubebuilder:printcolumn:name="Age",type="date",priority=0,JSONPath=".metadata.creationTimestamp"
 type Subscription struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/apis/v1alpha1/topic.go
+++ b/apis/v1alpha1/topic.go
@@ -83,6 +83,10 @@ type TopicStatus struct {
 // Topic is the Schema for the Topics API
 // +kubebuilder:object:root=true
 // +kubebuilder:subresource:status
+// +kubebuilder:printcolumn:name="ARN",type=string,priority=1,JSONPath=`.status.ackResourceMetadata.arn`
+// +kubebuilder:printcolumn:name="DISPLAYNAME",type=string,priority=0,JSONPath=`.spec.displayName`
+// +kubebuilder:printcolumn:name="Synced",type="string",priority=0,JSONPath=".status.conditions[?(@.type==\"ACK.ResourceSynced\")].status"
+// +kubebuilder:printcolumn:name="Age",type="date",priority=0,JSONPath=".metadata.creationTimestamp"
 type Topic struct {
 	metav1.TypeMeta   `json:",inline"`
 	metav1.ObjectMeta `json:"metadata,omitempty"`

--- a/config/crd/bases/sns.services.k8s.aws_subscriptions.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_subscriptions.yaml
@@ -14,7 +14,18 @@ spec:
     singular: subscription
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.ackResourceMetadata.arn
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+      name: Synced
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Subscription is the Schema for the Subscriptions API

--- a/config/crd/bases/sns.services.k8s.aws_topics.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_topics.yaml
@@ -14,7 +14,21 @@ spec:
     singular: topic
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.ackResourceMetadata.arn
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .spec.displayName
+      name: DISPLAYNAME
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+      name: Synced
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Topic is the Schema for the Topics API

--- a/generator.yaml
+++ b/generator.yaml
@@ -34,6 +34,18 @@ operations:
     operation_type: SET_ATTRIBUTES
 resources:
   Topic:
+    print:
+      add_age_column: true
+      add_synced_column: true
+      additional_columns:
+        - name: ARN
+          json_path: .status.ackResourceMetadata.arn
+          type: string
+          priority: 1 # shows only in -o view
+        - name: DISPLAYNAME
+          json_path: .spec.displayName
+          type: string
+          priority: 0
     is_arn_primary_key: true
     update_operation:
       custom_method_name: customUpdate
@@ -155,6 +167,14 @@ resources:
     tags:
       ignore: true
   Subscription:
+    print:
+      add_age_column: true
+      add_synced_column: true
+      additional_columns:
+        - name: ARN
+          json_path: .status.ackResourceMetadata.arn
+          type: string
+          priority: 1 # shows only in -o view
     is_arn_primary_key: true
     update_operation:
       custom_method_name: customUpdate

--- a/helm/crds/sns.services.k8s.aws_subscriptions.yaml
+++ b/helm/crds/sns.services.k8s.aws_subscriptions.yaml
@@ -14,7 +14,18 @@ spec:
     singular: subscription
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.ackResourceMetadata.arn
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+      name: Synced
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Subscription is the Schema for the Subscriptions API

--- a/helm/crds/sns.services.k8s.aws_topics.yaml
+++ b/helm/crds/sns.services.k8s.aws_topics.yaml
@@ -14,7 +14,21 @@ spec:
     singular: topic
   scope: Namespaced
   versions:
-  - name: v1alpha1
+  - additionalPrinterColumns:
+    - jsonPath: .status.ackResourceMetadata.arn
+      name: ARN
+      priority: 1
+      type: string
+    - jsonPath: .spec.displayName
+      name: DISPLAYNAME
+      type: string
+    - jsonPath: .status.conditions[?(@.type=="ACK.ResourceSynced")].status
+      name: Synced
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
     schema:
       openAPIV3Schema:
         description: Topic is the Schema for the Topics API


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2194

Adds additional printer columns (`ARN`, `Age`, `Synced`) to Topic and Subscription
CRDs to improve kubectl output. Topics also show `DisplayName`.

Output example:
```bash
k get topics
NAME        DISPLAYNAME   SYNCED   AGE
topic-123   My Topic      True     32m

k get subscriptions -owide
NAME               ARN                                                                                 SYNCED   AGE
subscription-123   arn:aws:sns:us-west-2:095708837592:topic-123:a140e042-4de4-44c3-b301-599672805647   True     25m

k get subscriptions
NAME               SYNCED   AGE
subscription-123   True     25m

k get subscriptions -owide
NAME               ARN                                                                                 SYNCED   AGE
subscription-123   arn:aws:sns:us-west-2:095708837592:topic-123:a140e042-4de4-44c3-b301-599672805647   True     25m
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
