### PR TITLE
remove getImmutableFieldChanges references

### DIFF
--- a/pkg/resource/topic/hooks.go
+++ b/pkg/resource/topic/hooks.go
@@ -17,7 +17,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"strings"
 
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
@@ -65,10 +64,6 @@ func (rm *resourceManager) customUpdate(
 	defer func() {
 		exit(err)
 	}()
-	if immutableFieldChanges := rm.getImmutableFieldChanges(delta); len(immutableFieldChanges) > 0 {
-		msg := fmt.Sprintf("Immutable Spec fields have been modified: %s", strings.Join(immutableFieldChanges, ","))
-		return nil, ackerr.NewTerminalError(fmt.Errorf(msg))
-	}
 	if delta.DifferentAt("Spec.Tags") {
 		if err := rm.syncTags(ctx, desired, latest); err != nil {
 			return nil, err

--- a/test/e2e/tests/test_topic.py
+++ b/test/e2e/tests/test_topic.py
@@ -177,19 +177,6 @@ class TestTopic:
             expect_after_update_tags, latest_tags,
         )
 
-        updates = {
-            "spec": {"name": "my-simple-topic-edited"}
-        }
-        k8s.patch_custom_resource(ref, updates)
-        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
-        k8s.wait_resource_consumed_by_controller(ref)
-        condition.assert_type_status(ref, condition.CONDITION_TYPE_TERMINAL) 
-
-        expected_msg = "Immutable Spec fields have been modified: Name"
-        terminal_condition = k8s.get_resource_condition(ref, condition.CONDITION_TYPE_TERMINAL)
-        # The name is immutable, testing if we get a terminal error
-        assert expected_msg in terminal_condition['message']
-
     def test_crud_fifo(self, fifo_topic):
         ref, res = fifo_topic
 


### PR DESCRIPTION
fix https://github.com/aws-controllers-k8s/code-generator/pull/565

Description of changes:
Remove getImmutableFieldChanges from hooks to support cel immutability

field `Name` immutability test removed for resource `Topic`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
