### PR TITLE
Generate with code-generator 0.47.1

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,8 +1,8 @@
 ack_generate_info:
-  build_date: "2025-05-13T04:44:06Z"
-  build_hash: 55bf57b2806c33a7fcd074be403f26ce3f8e58db
+  build_date: "2025-05-28T16:27:03Z"
+  build_hash: 66a58d259146834e61b211a9a01609beaa58ef77
   go_version: go1.24.2
-  version: v0.46.2
+  version: v0.47.1
 api_directory_checksum: 4c3a3e96fdcd7220a53c81643e6ffe572b04916b
 api_version: v1alpha1
 aws_sdk_go_version: v1.32.6

--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/sns-controller
-  newTag: 1.1.11
+  newTag: 1.1.12

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ toolchain go1.24.1
 require (
 	github.com/aws-controllers-k8s/iam-controller v1.1.1
 	github.com/aws-controllers-k8s/kms-controller v1.0.2
-	github.com/aws-controllers-k8s/runtime v0.46.1
+	github.com/aws-controllers-k8s/runtime v0.47.0
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.15

--- a/go.sum
+++ b/go.sum
@@ -2,8 +2,8 @@ github.com/aws-controllers-k8s/iam-controller v1.1.1 h1:O6arh7DNlQF26MEKzgA2/kBE
 github.com/aws-controllers-k8s/iam-controller v1.1.1/go.mod h1:2+ARwRpazTq5MErjMz0MpXHhtAzRfNtY56Uj0gvu9vE=
 github.com/aws-controllers-k8s/kms-controller v1.0.2 h1:v8nh/oaX/U6spCwBDaWyem7XXpzoP/MnkJyEjNOZN9s=
 github.com/aws-controllers-k8s/kms-controller v1.0.2/go.mod h1:BeoijsyGjJ9G5VcDjpFdxBW0IxaeKXYX497XmUJiPSQ=
-github.com/aws-controllers-k8s/runtime v0.46.1 h1:61RU6uYiFSp0cDhv52vAmaPzrebzoudtsp1fGkk6iLk=
-github.com/aws-controllers-k8s/runtime v0.46.1/go.mod h1:G2UMBKA7qgXG4JV16NTIUp715uqvUEvWaa7TG1I527U=
+github.com/aws-controllers-k8s/runtime v0.47.0 h1:pWzMLrwAFrAmMuSukYDLrQp5Yw594w1ke6XWGmI3uyo=
+github.com/aws-controllers-k8s/runtime v0.47.0/go.mod h1:G2UMBKA7qgXG4JV16NTIUp715uqvUEvWaa7TG1I527U=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sns-chart
 description: A Helm chart for the ACK service controller for Amazon Simple Notification Service (SNS)
-version: 1.1.11
-appVersion: 1.1.11
+version: 1.1.12
+appVersion: 1.1.12
 home: https://github.com/aws-controllers-k8s/sns-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/sns-controller:1.1.11".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/sns-controller:1.1.12".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/sns-controller
-  tag: 1.1.11
+  tag: 1.1.12
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Description of changes:
- Update runtime to v0.47.0
- Run code-generator v0.47.1
- Update patch version to 1.1.12

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
