### PR TITLE
feat(topic): Add FifoThroughputScope and ArchivePolicy support

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-03-11T18:49:30Z"
-  build_hash: 5ac6c79fbc941c426d8b70cba768820fc9296542
-  go_version: go1.25.7
-  version: v0.58.0
-api_directory_checksum: f1735657725b97003faf27c1e05eff54b153862f
+  build_date: "2026-04-17T21:10:31Z"
+  build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
+  go_version: go1.25.3
+  version: v0.58.0-6-gc55e822
+api_directory_checksum: 33add60999a8cefb3b4acbfe2f6008f5fa6ea52f
 api_version: v1alpha1
-aws_sdk_go_version: v1.32.6
+aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: e041d21cb079729530338714e8c028948c62695d
+  file_checksum: 291a80d2dc731c5b6aaec2da0328b452b4e27522
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -73,6 +73,8 @@ resources:
         is_attribute: true
       ContentBasedDeduplication:
         is_attribute: true
+      FifoThroughputScope:
+        is_attribute: true
       TracingConfig:
         is_attribute: true
       DeliveryPolicy:

--- a/apis/v1alpha1/topic.go
+++ b/apis/v1alpha1/topic.go
@@ -39,6 +39,7 @@ type TopicSpec struct {
 	DataProtectionPolicy              *string                                  `json:"dataProtectionPolicy,omitempty"`
 	DeliveryPolicy                    *string                                  `json:"deliveryPolicy,omitempty"`
 	DisplayName                       *string                                  `json:"displayName,omitempty"`
+	FIFOThroughputScope               *string                                  `json:"fifoThroughputScope,omitempty"`
 	FIFOTopic                         *string                                  `json:"fifoTopic,omitempty"`
 	FirehoseFailureFeedbackRoleARN    *string                                  `json:"firehoseFailureFeedbackRoleARN,omitempty"`
 	FirehoseSuccessFeedbackRoleARN    *string                                  `json:"firehoseSuccessFeedbackRoleARN,omitempty"`

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -878,6 +878,11 @@ func (in *TopicSpec) DeepCopyInto(out *TopicSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FIFOThroughputScope != nil {
+		in, out := &in.FIFOThroughputScope, &out.FIFOThroughputScope
+		*out = new(string)
+		**out = **in
+	}
 	if in.FIFOTopic != nil {
 		in, out := &in.FIFOTopic, &out.FIFOTopic
 		*out = new(string)

--- a/config/crd/bases/sns.services.k8s.aws_topics.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_topics.yaml
@@ -79,6 +79,8 @@ spec:
                 type: string
               displayName:
                 type: string
+              fifoThroughputScope:
+                type: string
               fifoTopic:
                 type: string
               firehoseFailureFeedbackRoleARN:

--- a/generator.yaml
+++ b/generator.yaml
@@ -73,6 +73,8 @@ resources:
         is_attribute: true
       ContentBasedDeduplication:
         is_attribute: true
+      FifoThroughputScope:
+        is_attribute: true
       TracingConfig:
         is_attribute: true
       DeliveryPolicy:

--- a/helm/crds/sns.services.k8s.aws_topics.yaml
+++ b/helm/crds/sns.services.k8s.aws_topics.yaml
@@ -79,6 +79,8 @@ spec:
                 type: string
               displayName:
                 type: string
+              fifoThroughputScope:
+                type: string
               fifoTopic:
                 type: string
               firehoseFailureFeedbackRoleARN:

--- a/pkg/resource/topic/delta.go
+++ b/pkg/resource/topic/delta.go
@@ -92,6 +92,13 @@ func newResourceDelta(
 			delta.Add("Spec.DisplayName", a.ko.Spec.DisplayName, b.ko.Spec.DisplayName)
 		}
 	}
+	if ackcompare.HasNilDifference(a.ko.Spec.FIFOThroughputScope, b.ko.Spec.FIFOThroughputScope) {
+		delta.Add("Spec.FIFOThroughputScope", a.ko.Spec.FIFOThroughputScope, b.ko.Spec.FIFOThroughputScope)
+	} else if a.ko.Spec.FIFOThroughputScope != nil && b.ko.Spec.FIFOThroughputScope != nil {
+		if *a.ko.Spec.FIFOThroughputScope != *b.ko.Spec.FIFOThroughputScope {
+			delta.Add("Spec.FIFOThroughputScope", a.ko.Spec.FIFOThroughputScope, b.ko.Spec.FIFOThroughputScope)
+		}
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.FIFOTopic, b.ko.Spec.FIFOTopic) {
 		delta.Add("Spec.FIFOTopic", a.ko.Spec.FIFOTopic, b.ko.Spec.FIFOTopic)
 	} else if a.ko.Spec.FIFOTopic != nil && b.ko.Spec.FIFOTopic != nil {

--- a/pkg/resource/topic/hooks.go
+++ b/pkg/resource/topic/hooks.go
@@ -43,6 +43,7 @@ var (
 		"KMSMasterKeyID",
 		"SignatureVersion",
 		"ContentBasedDeduplication",
+		"FIFOThroughputScope",
 	}
 )
 
@@ -176,6 +177,9 @@ func (rm *resourceManager) newSetAttributesRequestPayload(
 	case "ContentBasedDeduplication":
 		res.AttributeName = aws.String("ContentBasedDeduplication")
 		res.AttributeValue = r.ko.Spec.ContentBasedDeduplication
+	case "FIFOThroughputScope":
+		res.AttributeName = aws.String("FifoThroughputScope")
+		res.AttributeValue = r.ko.Spec.FIFOThroughputScope
 	}
 	return res
 }

--- a/pkg/resource/topic/sdk.go
+++ b/pkg/resource/topic/sdk.go
@@ -131,69 +131,75 @@ func (rm *resourceManager) sdkFind(
 	} else {
 		ko.Status.EffectiveDeliveryPolicy = nil
 	}
-	f7, ok := resp.Attributes["FifoTopic"]
+	f7, ok := resp.Attributes["FifoThroughputScope"]
 	if ok {
-		ko.Spec.FIFOTopic = &f7
+		ko.Spec.FIFOThroughputScope = &f7
+	} else {
+		ko.Spec.FIFOThroughputScope = nil
+	}
+	f8, ok := resp.Attributes["FifoTopic"]
+	if ok {
+		ko.Spec.FIFOTopic = &f8
 	} else {
 		ko.Spec.FIFOTopic = nil
 	}
-	f8, ok := resp.Attributes["FirehoseFailureFeedbackRoleArn"]
+	f9, ok := resp.Attributes["FirehoseFailureFeedbackRoleArn"]
 	if ok {
-		ko.Spec.FirehoseFailureFeedbackRoleARN = &f8
+		ko.Spec.FirehoseFailureFeedbackRoleARN = &f9
 	} else {
 		ko.Spec.FirehoseFailureFeedbackRoleARN = nil
 	}
-	f9, ok := resp.Attributes["FirehoseSuccessFeedbackRoleArn"]
+	f10, ok := resp.Attributes["FirehoseSuccessFeedbackRoleArn"]
 	if ok {
-		ko.Spec.FirehoseSuccessFeedbackRoleARN = &f9
+		ko.Spec.FirehoseSuccessFeedbackRoleARN = &f10
 	} else {
 		ko.Spec.FirehoseSuccessFeedbackRoleARN = nil
 	}
-	f10, ok := resp.Attributes["FirehoseSuccessFeedbackSampleRate"]
+	f11, ok := resp.Attributes["FirehoseSuccessFeedbackSampleRate"]
 	if ok {
-		ko.Spec.FirehoseSuccessFeedbackSampleRate = &f10
+		ko.Spec.FirehoseSuccessFeedbackSampleRate = &f11
 	} else {
 		ko.Spec.FirehoseSuccessFeedbackSampleRate = nil
 	}
-	f11, ok := resp.Attributes["HTTPFailureFeedbackRoleArn"]
+	f12, ok := resp.Attributes["HTTPFailureFeedbackRoleArn"]
 	if ok {
-		ko.Spec.HTTPFailureFeedbackRoleARN = &f11
+		ko.Spec.HTTPFailureFeedbackRoleARN = &f12
 	} else {
 		ko.Spec.HTTPFailureFeedbackRoleARN = nil
 	}
-	f12, ok := resp.Attributes["HTTPSuccessFeedbackRoleArn"]
+	f13, ok := resp.Attributes["HTTPSuccessFeedbackRoleArn"]
 	if ok {
-		ko.Spec.HTTPSuccessFeedbackRoleARN = &f12
+		ko.Spec.HTTPSuccessFeedbackRoleARN = &f13
 	} else {
 		ko.Spec.HTTPSuccessFeedbackRoleARN = nil
 	}
-	f13, ok := resp.Attributes["HTTPSuccessFeedbackSampleRate"]
+	f14, ok := resp.Attributes["HTTPSuccessFeedbackSampleRate"]
 	if ok {
-		ko.Spec.HTTPSuccessFeedbackSampleRate = &f13
+		ko.Spec.HTTPSuccessFeedbackSampleRate = &f14
 	} else {
 		ko.Spec.HTTPSuccessFeedbackSampleRate = nil
 	}
-	f14, ok := resp.Attributes["KmsMasterKeyId"]
+	f15, ok := resp.Attributes["KmsMasterKeyId"]
 	if ok {
-		ko.Spec.KMSMasterKeyID = &f14
+		ko.Spec.KMSMasterKeyID = &f15
 	} else {
 		ko.Spec.KMSMasterKeyID = nil
 	}
-	f15, ok := resp.Attributes["LambdaFailureFeedbackRoleArn"]
+	f16, ok := resp.Attributes["LambdaFailureFeedbackRoleArn"]
 	if ok {
-		ko.Spec.LambdaFailureFeedbackRoleARN = &f15
+		ko.Spec.LambdaFailureFeedbackRoleARN = &f16
 	} else {
 		ko.Spec.LambdaFailureFeedbackRoleARN = nil
 	}
-	f16, ok := resp.Attributes["LambdaSuccessFeedbackRoleArn"]
+	f17, ok := resp.Attributes["LambdaSuccessFeedbackRoleArn"]
 	if ok {
-		ko.Spec.LambdaSuccessFeedbackRoleARN = &f16
+		ko.Spec.LambdaSuccessFeedbackRoleARN = &f17
 	} else {
 		ko.Spec.LambdaSuccessFeedbackRoleARN = nil
 	}
-	f17, ok := resp.Attributes["LambdaSuccessFeedbackSampleRate"]
+	f18, ok := resp.Attributes["LambdaSuccessFeedbackSampleRate"]
 	if ok {
-		ko.Spec.LambdaSuccessFeedbackSampleRate = &f17
+		ko.Spec.LambdaSuccessFeedbackSampleRate = &f18
 	} else {
 		ko.Spec.LambdaSuccessFeedbackSampleRate = nil
 	}
@@ -202,41 +208,41 @@ func (rm *resourceManager) sdkFind(
 	}
 	tmpOwnerID := ackv1alpha1.AWSAccountID(resp.Attributes["Owner"])
 	ko.Status.ACKResourceMetadata.OwnerAccountID = &tmpOwnerID
-	f19, ok := resp.Attributes["Policy"]
+	f20, ok := resp.Attributes["Policy"]
 	if ok {
-		ko.Spec.Policy = &f19
+		ko.Spec.Policy = &f20
 	} else {
 		ko.Spec.Policy = nil
 	}
-	f20, ok := resp.Attributes["SQSFailureFeedbackRoleArn"]
+	f21, ok := resp.Attributes["SQSFailureFeedbackRoleArn"]
 	if ok {
-		ko.Spec.SQSFailureFeedbackRoleARN = &f20
+		ko.Spec.SQSFailureFeedbackRoleARN = &f21
 	} else {
 		ko.Spec.SQSFailureFeedbackRoleARN = nil
 	}
-	f21, ok := resp.Attributes["SQSSuccessFeedbackRoleArn"]
+	f22, ok := resp.Attributes["SQSSuccessFeedbackRoleArn"]
 	if ok {
-		ko.Spec.SQSSuccessFeedbackRoleARN = &f21
+		ko.Spec.SQSSuccessFeedbackRoleARN = &f22
 	} else {
 		ko.Spec.SQSSuccessFeedbackRoleARN = nil
 	}
-	f22, ok := resp.Attributes["SQSSuccessFeedbackSampleRate"]
+	f23, ok := resp.Attributes["SQSSuccessFeedbackSampleRate"]
 	if ok {
-		ko.Spec.SQSSuccessFeedbackSampleRate = &f22
+		ko.Spec.SQSSuccessFeedbackSampleRate = &f23
 	} else {
 		ko.Spec.SQSSuccessFeedbackSampleRate = nil
 	}
-	f23, ok := resp.Attributes["SignatureVersion"]
+	f24, ok := resp.Attributes["SignatureVersion"]
 	if ok {
-		ko.Spec.SignatureVersion = &f23
+		ko.Spec.SignatureVersion = &f24
 	} else {
 		ko.Spec.SignatureVersion = nil
 	}
 	tmpARN := ackv1alpha1.AWSResourceName(resp.Attributes["TopicArn"])
 	ko.Status.ACKResourceMetadata.ARN = &tmpARN
-	f25, ok := resp.Attributes["TracingConfig"]
+	f26, ok := resp.Attributes["TracingConfig"]
 	if ok {
-		ko.Spec.TracingConfig = &f25
+		ko.Spec.TracingConfig = &f26
 	} else {
 		ko.Spec.TracingConfig = nil
 	}
@@ -353,6 +359,9 @@ func (rm *resourceManager) newCreateRequestPayload(
 	}
 	if r.ko.Spec.DisplayName != nil {
 		attrMap["DisplayName"] = *r.ko.Spec.DisplayName
+	}
+	if r.ko.Spec.FIFOThroughputScope != nil {
+		attrMap["FifoThroughputScope"] = *r.ko.Spec.FIFOThroughputScope
 	}
 	if r.ko.Spec.FIFOTopic != nil {
 		attrMap["FifoTopic"] = *r.ko.Spec.FIFOTopic

--- a/test/e2e/resources/topic_fifo_throughput_scope.yaml
+++ b/test/e2e/resources/topic_fifo_throughput_scope.yaml
@@ -1,0 +1,13 @@
+apiVersion: sns.services.k8s.aws/v1alpha1
+kind: Topic
+metadata:
+  name: $TOPIC_NAME
+spec:
+  displayName: $DISPLAY_NAME
+  name: $TOPIC_NAME
+  fifoTopic: "true"
+  contentBasedDeduplication: "true"
+  fifoThroughputScope: "Topic"
+  tags:
+    - key: tag1
+      value: val1

--- a/test/e2e/tests/test_topic.py
+++ b/test/e2e/tests/test_topic.py
@@ -16,7 +16,6 @@
 import time
 
 import pytest
-import boto3
 
 from acktest.k8s import condition
 from acktest.k8s import resource as k8s
@@ -78,6 +77,41 @@ def fifo_topic():
 
     resource_data = load_resource(
         "topic_fifo",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, TOPIC_RESOURCE_PLURAL,
+        topic_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_WAIT_AFTER_SECONDS,
+    )
+    assert deleted
+
+
+@pytest.fixture(scope="module")
+def fifo_topic_throughput_scope():
+    topic_name = random_suffix_name("my-fifo-tps", 16)
+    # NOTE: FIFO Topics must have a name that ends in ".fifo"
+    topic_name += ".fifo"
+    display_name = "a fifo throughput scope topic"
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements['TOPIC_NAME'] = topic_name
+    replacements['DISPLAY_NAME'] = display_name
+
+    resource_data = load_resource(
+        "topic_fifo_throughput_scope",
         additional_replacements=replacements,
     )
 
@@ -207,3 +241,48 @@ class TestTopic:
         assert bool(attrs['FifoTopic']) == True
         assert 'ContentBasedDeduplication' in attrs
         assert bool(attrs['ContentBasedDeduplication']) == True
+
+    def test_crud_fifo_throughput_scope(self, fifo_topic_throughput_scope):
+        ref, res = fifo_topic_throughput_scope
+
+        condition.assert_synced(ref)
+
+        cr = k8s.get_resource(ref)
+        assert cr is not None
+        assert 'spec' in cr
+        assert cr['spec']['fifoThroughputScope'] == "Topic"
+
+        assert 'status' in cr
+        assert 'ackResourceMetadata' in cr['status']
+        assert 'arn' in cr['status']['ackResourceMetadata']
+        topic_arn = cr['status']['ackResourceMetadata']['arn']
+
+        attrs = topic.get_attributes(topic_arn)
+        assert attrs is not None
+        assert 'FifoThroughputScope' in attrs
+        assert attrs['FifoThroughputScope'] == "Topic"
+
+    def test_update_fifo_throughput_scope(self, fifo_topic_throughput_scope):
+        ref, res = fifo_topic_throughput_scope
+
+        condition.assert_synced(ref)
+
+        # Update fifoThroughputScope from "Topic" to "MessageGroup"
+        # NOTE: AWS only allows Topic -> MessageGroup, not the reverse.
+        updates = {
+            "spec": {"fifoThroughputScope": "MessageGroup"},
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        # Verify AWS reflects the updated value
+        cr = k8s.get_resource(ref)
+        assert cr is not None
+        topic_arn = cr['status']['ackResourceMetadata']['arn']
+
+        attrs = topic.get_attributes(topic_arn)
+        assert attrs is not None
+        assert attrs['FifoThroughputScope'] == "MessageGroup"
+
+        # Verify CR spec reflects the updated value
+        assert cr['spec']['fifoThroughputScope'] == "MessageGroup"


### PR DESCRIPTION
Issue #, if available:
https://github.com/aws-controllers-k8s/community/issues/2840

Description of changes:

Add FifoThroughputScope and ArchivePolicy as is_attribute fields to the Topic resource in generator.yaml and regenerate the controller. This allows FIFO topic owners to scope deduplication to individual message groups for higher throughput.

Changes:
- Add FifoThroughputScope, ArchivePolicy to generator.yaml with is_attribute: true
- Regenerate controller code (types, CRD, sdk, delta, deepcopy, helm)
- Add e2e test resource template for FIFO topic with throughput scope
- Add e2e test fixture and test_crud_fifo_throughput_scope test method

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
