### PR TITLE
Release artifacts for release v1.4.0

### DIFF
--- a/config/controller/kustomization.yaml
+++ b/config/controller/kustomization.yaml
@@ -6,4 +6,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: public.ecr.aws/aws-controllers-k8s/sns-controller
-  newTag: 1.3.2
+  newTag: 1.4.0

--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 name: sns-chart
 description: A Helm chart for the ACK service controller for Amazon Simple Notification Service (SNS)
-version: 1.3.2
-appVersion: 1.3.2
+version: 1.4.0
+appVersion: 1.4.0
 home: https://github.com/aws-controllers-k8s/sns-controller
 icon: https://raw.githubusercontent.com/aws/eks-charts/master/docs/logo/aws.png
 sources:

--- a/helm/templates/NOTES.txt
+++ b/helm/templates/NOTES.txt
@@ -1,5 +1,5 @@
 {{ .Chart.Name }} has been installed.
-This chart deploys "public.ecr.aws/aws-controllers-k8s/sns-controller:1.3.2".
+This chart deploys "public.ecr.aws/aws-controllers-k8s/sns-controller:1.4.0".
 
 Check its status by running:
   kubectl --namespace {{ .Release.Namespace }} get pods -l "app.kubernetes.io/instance={{ .Release.Name }}"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -4,7 +4,7 @@
 
 image:
   repository: public.ecr.aws/aws-controllers-k8s/sns-controller
-  tag: 1.3.2
+  tag: 1.4.0
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

## Release v1.4.0

### Changes since v1.3.2

- feat(topic): Add `FifoThroughputScope` support (#108)
  - Adds `FifoThroughputScope` as `is_attribute` fields to the Topic resource
  - Allows FIFO topic owners to scope deduplication to individual message groups for higher throughput
  - Includes e2e tests for FIFO topic throughput scope

Related issue: https://github.com/aws-controllers-k8s/community/issues/2840

### Release artifacts

Generated using `build-controller-release.sh` with `RELEASE_VERSION=v1.4.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
