### PR TITLE
fix: Use IAM policy comparator for sns topic policy

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-04-22T18:24:43Z"
+  build_date: "2026-04-23T20:57:38Z"
   build_hash: c55e8227b1ff5ac6a8b8e1421a2f2076fa6a77bd
-  go_version: go1.26.2
+  go_version: go1.26.0
   version: v0.58.1
 api_directory_checksum: 33add60999a8cefb3b4acbfe2f6008f5fa6ea52f
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 291a80d2dc731c5b6aaec2da0328b452b4e27522
+  file_checksum: 2a25be116261edd9cb17f1797df282045143ebfa
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -82,6 +82,7 @@ resources:
       DisplayName:
         is_attribute: true
       Policy:
+        is_iam_policy: true
         is_attribute: true
         type: string
         references:

--- a/generator.yaml
+++ b/generator.yaml
@@ -82,6 +82,7 @@ resources:
       DisplayName:
         is_attribute: true
       Policy:
+        is_iam_policy: true
         is_attribute: true
         type: string
         references:

--- a/pkg/resource/topic/delta.go
+++ b/pkg/resource/topic/delta.go
@@ -189,7 +189,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.Policy, b.ko.Spec.Policy) {
 		delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 	} else if a.ko.Spec.Policy != nil && b.ko.Spec.Policy != nil {
-		if *a.ko.Spec.Policy != *b.ko.Spec.Policy {
+		if equal, err := ackcompare.IAMPolicyDocumentEqual(*a.ko.Spec.Policy, *b.ko.Spec.Policy); err != nil || !equal {
 			delta.Add("Spec.Policy", a.ko.Spec.Policy, b.ko.Spec.Policy)
 		}
 	}


### PR DESCRIPTION
Issue [#2869](https://github.com/aws-controllers-k8s/community/issues/2869)

Description of changes:
IAM policy comparator ensures any changes that don't affect the policy
spec are ignored (eg. whitespaces, order changes, etc)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
