### PR TITLE
Fix incorrect delta for FilterPolicy

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-11T06:24:59Z"
-  build_hash: 119cbe3fb4412c17107b73761dac9eeef484f36a
+  build_date: "2026-05-13T05:03:02Z"
+  build_hash: b061ffd6a5fa8ee4286c29b9f4bbac39f24f93ee
   go_version: go1.26.0
-  version: v0.58.1-7-g119cbe3
+  version: v0.58.1-8-gb061ffd
 api_directory_checksum: 33add60999a8cefb3b4acbfe2f6008f5fa6ea52f
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 9321063d9a4e63789a50779a5092efe4cf73ccc5
+  file_checksum: 564aea7c1bdcc908ae8590a7ccd2def652735da6
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -240,6 +240,7 @@ resources:
        is_immutable: true
       FilterPolicy:
         is_attribute: true
+        is_document: true
       FilterPolicyScope:
         is_attribute: true
       Owner:

--- a/generator.yaml
+++ b/generator.yaml
@@ -240,6 +240,7 @@ resources:
        is_immutable: true
       FilterPolicy:
         is_attribute: true
+        is_document: true
       FilterPolicyScope:
         is_attribute: true
       Owner:

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.25.0
 require (
 	github.com/aws-controllers-k8s/iam-controller v1.1.1
 	github.com/aws-controllers-k8s/kms-controller v1.0.2
-	github.com/aws-controllers-k8s/runtime v0.58.2-0.20260508231111-2345cb4c58b1
+	github.com/aws-controllers-k8s/runtime v0.58.2-0.20260512210412-61d58ad3edb8
 	github.com/aws/aws-sdk-go v1.49.0
 	github.com/aws/aws-sdk-go-v2 v1.34.0
 	github.com/aws/aws-sdk-go-v2/service/sns v1.33.15
@@ -54,7 +54,7 @@ require (
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/mailru/easyjson v0.7.7 // indirect
-	github.com/micahhausler/aws-iam-policy v0.4.4 // indirect
+	github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.3-0.20250322232337-35a7c28c31ee // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/aws-controllers-k8s/iam-controller v1.1.1 h1:O6arh7DNlQF26MEKzgA2/kBE
 github.com/aws-controllers-k8s/iam-controller v1.1.1/go.mod h1:2+ARwRpazTq5MErjMz0MpXHhtAzRfNtY56Uj0gvu9vE=
 github.com/aws-controllers-k8s/kms-controller v1.0.2 h1:v8nh/oaX/U6spCwBDaWyem7XXpzoP/MnkJyEjNOZN9s=
 github.com/aws-controllers-k8s/kms-controller v1.0.2/go.mod h1:BeoijsyGjJ9G5VcDjpFdxBW0IxaeKXYX497XmUJiPSQ=
-github.com/aws-controllers-k8s/runtime v0.58.2-0.20260508231111-2345cb4c58b1 h1:qSe/7eiW3Euaav1yk9Y6SPgiD6E2W4XSEUszopNNS3A=
-github.com/aws-controllers-k8s/runtime v0.58.2-0.20260508231111-2345cb4c58b1/go.mod h1:WPlOiAG+xGySh1I076llz5g6nbuUeH62Qxh49hnieGo=
+github.com/aws-controllers-k8s/runtime v0.58.2-0.20260512210412-61d58ad3edb8 h1:QpT5HxytMq82Lfr7ouaWTBI7E/xHcmo4y6o00HuITUQ=
+github.com/aws-controllers-k8s/runtime v0.58.2-0.20260512210412-61d58ad3edb8/go.mod h1:ljWD1IdtVx/qC7C4lVobF4vLNhno/xX5A78BOke1Ksk=
 github.com/aws/aws-sdk-go v1.49.0 h1:g9BkW1fo9GqKfwg2+zCD+TW/D36Ux+vtfJ8guF4AYmY=
 github.com/aws/aws-sdk-go v1.49.0/go.mod h1:LF8svs817+Nz+DmiMQKTO3ubZ/6IaTpq3TjupRn3Eqk=
 github.com/aws/aws-sdk-go-v2 v1.34.0 h1:9iyL+cjifckRGEVpRKZP3eIxVlL06Qk1Tk13vreaVQU=
@@ -114,8 +114,8 @@ github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0
 github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
-github.com/micahhausler/aws-iam-policy v0.4.4 h1:1aMhJ+0CkvUJ8HGN1chX+noXHs8uvGLkD7xIBeYd31c=
-github.com/micahhausler/aws-iam-policy v0.4.4/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2 h1:J1D4vj3/AVzVoo1allyJJD3mh7J6bPWXVoQHOBQ+p5Y=
+github.com/micahhausler/aws-iam-policy v0.4.5-0.20260511184658-411e29b8ffd2/go.mod h1:H+yWljTu4XWJjNJJYgrPUai0AUTGNHc8pumkN57/foI=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=

--- a/pkg/resource/subscription/delta.go
+++ b/pkg/resource/subscription/delta.go
@@ -60,7 +60,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.FilterPolicy, b.ko.Spec.FilterPolicy) {
 		delta.Add("Spec.FilterPolicy", a.ko.Spec.FilterPolicy, b.ko.Spec.FilterPolicy)
 	} else if a.ko.Spec.FilterPolicy != nil && b.ko.Spec.FilterPolicy != nil {
-		if *a.ko.Spec.FilterPolicy != *b.ko.Spec.FilterPolicy {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.FilterPolicy, *b.ko.Spec.FilterPolicy); err != nil || !equal {
 			delta.Add("Spec.FilterPolicy", a.ko.Spec.FilterPolicy, b.ko.Spec.FilterPolicy)
 		}
 	}

--- a/pkg/resource/subscription/delta_test.go
+++ b/pkg/resource/subscription/delta_test.go
@@ -1,0 +1,126 @@
+// Copyright Amazon.com Inc. or its affiliates. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"). You may
+// not use this file except in compliance with the License. A copy of the
+// License is located at
+//
+//     http://aws.amazon.com/apache2.0/
+//
+// or in the "license" file accompanying this file. This file is distributed
+// on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+// express or implied. See the License for the specific language governing
+// permissions and limitations under the License.
+
+package subscription
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/stretchr/testify/assert"
+
+	svcapitypes "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1"
+)
+
+// helper to build a *resource with only FilterPolicy set.
+func subscriptionWithFilterPolicy(filterPolicy *string) *resource {
+	return &resource{
+		ko: &svcapitypes.Subscription{
+			Spec: svcapitypes.SubscriptionSpec{
+				TopicARN:     aws.String("arn:aws:sns:us-east-1:123456789012:my-topic"),
+				Protocol:     aws.String("sqs"),
+				Endpoint:     aws.String("arn:aws:sqs:us-east-1:123456789012:my-queue"),
+				FilterPolicy: filterPolicy,
+			},
+		},
+	}
+}
+
+func TestNewResourceDelta_FilterPolicy_JSONComparison(t *testing.T) {
+	tests := []struct {
+		name     string
+		desired  *string
+		latest   *string
+		wantDiff bool
+	}{
+		{
+			name:     "both nil produces no diff",
+			desired:  nil,
+			latest:   nil,
+			wantDiff: false,
+		},
+		{
+			name:     "desired nil latest non-nil produces diff",
+			desired:  nil,
+			latest:   aws.String(`{"key":["value"]}`),
+			wantDiff: true,
+		},
+		{
+			name:     "desired non-nil latest nil produces diff",
+			desired:  aws.String(`{"key":["value"]}`),
+			latest:   nil,
+			wantDiff: true,
+		},
+		{
+			name:     "identical JSON strings produce no diff",
+			desired:  aws.String(`{"notificationOrigin":["PRODUCT"]}`),
+			latest:   aws.String(`{"notificationOrigin":["PRODUCT"]}`),
+			wantDiff: false,
+		},
+		{
+			name:     "pretty vs compact JSON produces no diff (issue 2877)",
+			desired:  aws.String("{\n  \"notificationOrigin\": [\n    \"PRODUCT\"\n  ],\n  \"productType\": [\n    {\n      \"anything-but\": \"simple\"\n    }\n  ]\n}\n"),
+			latest:   aws.String(`{"notificationOrigin":["PRODUCT"],"productType":[{"anything-but":"simple"}]}`),
+			wantDiff: false,
+		},
+		{
+			name:     "trailing newline from YAML block scalar produces no diff",
+			desired:  aws.String("{\"notificationOrigin\":[\"PRODUCT\"]}\n"),
+			latest:   aws.String(`{"notificationOrigin":["PRODUCT"]}`),
+			wantDiff: false,
+		},
+		{
+			name:     "different key ordering produces no diff",
+			desired:  aws.String(`{"productType":[{"anything-but":"simple"}],"notificationOrigin":["PRODUCT"]}`),
+			latest:   aws.String(`{"notificationOrigin":["PRODUCT"],"productType":[{"anything-but":"simple"}]}`),
+			wantDiff: false,
+		},
+		{
+			name:     "whitespace differences produce no diff",
+			desired:  aws.String("{\n  \"notificationOrigin\": [\n    \"PRODUCT\"\n  ]\n}"),
+			latest:   aws.String(`{"notificationOrigin":["PRODUCT"]}`),
+			wantDiff: false,
+		},
+		{
+			name:     "different filter values produce diff",
+			desired:  aws.String(`{"notificationOrigin":["PRODUCT"]}`),
+			latest:   aws.String(`{"notificationOrigin":["ORDER"]}`),
+			wantDiff: true,
+		},
+		{
+			name:     "extra filter key produces diff",
+			desired:  aws.String(`{"notificationOrigin":["PRODUCT"]}`),
+			latest:   aws.String(`{"notificationOrigin":["PRODUCT"],"productType":["simple"]}`),
+			wantDiff: true,
+		},
+		{
+			name:     "different nested structure produces diff",
+			desired:  aws.String(`{"productType":[{"anything-but":"simple"}]}`),
+			latest:   aws.String(`{"productType":["simple"]}`),
+			wantDiff: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired := subscriptionWithFilterPolicy(tt.desired)
+			latest := subscriptionWithFilterPolicy(tt.latest)
+
+			delta := newResourceDelta(desired, latest)
+			hasDiff := delta.DifferentAt("Spec.FilterPolicy")
+
+			assert.Equal(t, tt.wantDiff, hasDiff,
+				"DifferentAt(Spec.FilterPolicy) = %v, want %v", hasDiff, tt.wantDiff)
+		})
+	}
+}


### PR DESCRIPTION
# Fix incorrect delta comparison for Subscription FilterPolicy

## Problem

The SNS controller performed a simple string comparison on the `FilterPolicy` field. This caused infinite reconciliation loops https://github.com/aws-controllers-k8s/community/issues/2872

## Solution

- Marked `FilterPolicy` as `is_document: true` in `generator.yaml`, triggering semantic JSON comparison via `ackcompare.DocumentEqual` from the ACK runtime.
- Updated the runtime dependency to `v0.58.2-0.20260512210412-61d58ad3edb8` which includes the `DocumentEqual` function.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
