### PR TITLE
Mark Subscription DeliveryPolicy and RedrivePolicy as is_document for semantic JSON comparison

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-05-19T18:49:03Z"
-  build_hash: e581e886276bd781409a3fb11fa665ea31de17d4
-  go_version: go1.26.3
-  version: v0.59.1
+  build_date: "2026-06-17T01:07:09Z"
+  build_hash: 8b46cc24f655c464e4221f893e710865d7ae600a
+  go_version: go1.26.0
+  version: v0.59.1-1-g8b46cc2
 api_directory_checksum: 33add60999a8cefb3b4acbfe2f6008f5fa6ea52f
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 564aea7c1bdcc908ae8590a7ccd2def652735da6
+  file_checksum: 6b68d67160856c06ea5f168bd16e213d26c8e24f
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -233,6 +233,7 @@ resources:
         is_read_only: true
       DeliveryPolicy:
         is_attribute: true
+        is_document: true
       EffectiveDeliveryPolicy:
         is_attribute: true
         is_read_only: true
@@ -254,6 +255,7 @@ resources:
         is_attribute: true
       RedrivePolicy:
         is_attribute: true
+        is_document: true
       SubscriptionRoleArn:
         is_attribute: true
       TopicArn:

--- a/generator.yaml
+++ b/generator.yaml
@@ -233,6 +233,7 @@ resources:
         is_read_only: true
       DeliveryPolicy:
         is_attribute: true
+        is_document: true
       EffectiveDeliveryPolicy:
         is_attribute: true
         is_read_only: true
@@ -254,6 +255,7 @@ resources:
         is_attribute: true
       RedrivePolicy:
         is_attribute: true
+        is_document: true
       SubscriptionRoleArn:
         is_attribute: true
       TopicArn:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -2,7 +2,7 @@ service:
   full_name: "Amazon Simple Notification Service"
   short_name: "SNS"
   link: "https://aws.amazon.com/sns/"
-  documentation: "https://docs.aws.amazon.com/sns/latest/api/welcome.html"
+  documentation: "https://docs.aws.amazon.com/sns/latest/api/Welcome.html"
 api_versions:
   - api_version: v1alpha1
     status: available

--- a/pkg/resource/subscription/delta.go
+++ b/pkg/resource/subscription/delta.go
@@ -46,7 +46,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy) {
 		delta.Add("Spec.DeliveryPolicy", a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy)
 	} else if a.ko.Spec.DeliveryPolicy != nil && b.ko.Spec.DeliveryPolicy != nil {
-		if *a.ko.Spec.DeliveryPolicy != *b.ko.Spec.DeliveryPolicy {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.DeliveryPolicy, *b.ko.Spec.DeliveryPolicy); err != nil || !equal {
 			delta.Add("Spec.DeliveryPolicy", a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy)
 		}
 	}
@@ -88,7 +88,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.RedrivePolicy, b.ko.Spec.RedrivePolicy) {
 		delta.Add("Spec.RedrivePolicy", a.ko.Spec.RedrivePolicy, b.ko.Spec.RedrivePolicy)
 	} else if a.ko.Spec.RedrivePolicy != nil && b.ko.Spec.RedrivePolicy != nil {
-		if *a.ko.Spec.RedrivePolicy != *b.ko.Spec.RedrivePolicy {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.RedrivePolicy, *b.ko.Spec.RedrivePolicy); err != nil || !equal {
 			delta.Add("Spec.RedrivePolicy", a.ko.Spec.RedrivePolicy, b.ko.Spec.RedrivePolicy)
 		}
 	}

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -136,3 +136,26 @@ class TestSubscription:
         assert 'healthyRetryPolicy' in got_delivery_policy
         exp_healthy_retry_policy = delivery_policy['healthyRetryPolicy']
         assert exp_healthy_retry_policy == got_delivery_policy['healthyRetryPolicy']
+
+        # Verify semantic JSON comparison (is_document): patch with the same
+        # logical JSON but different key ordering. With DocumentEqual, this
+        # should NOT trigger a reconciliation loop or unnecessary update.
+        reordered_policy = {
+            "healthyRetryPolicy": {
+                "backoffFunction": "exponential",
+                "numMaxDelayRetries": 35,
+                "numMinDelayRetries": 2,
+                "numNoDelayRetries": 3,
+                "numRetries": 50,
+                "maxDelayTarget": 60,
+                "minDelayTarget": 1
+            }
+        }
+        updates = {
+            "spec": {"deliveryPolicy": json.dumps(reordered_policy)},
+        }
+        k8s.patch_custom_resource(sub_ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+
+        # Should still be synced — no unnecessary update triggered
+        condition.assert_synced(sub_ref)


### PR DESCRIPTION
## Problem

The SNS Subscription `DeliveryPolicy` and `RedrivePolicy` fields are strings containing JSON documents. Without the `is_document` annotation, the controller uses raw string comparison (`!=`) for delta detection. This causes unnecessary reconciliation loops when AWS returns the JSON content with different whitespace or key ordering than what was originally submitted.

This is the same class of issue fixed in ssm-controller#70 for the Document `Content` field, and the same pattern already applied to the Subscription `FilterPolicy` field in this controller.

## Solution

Added `is_document: true` to both `Subscription.DeliveryPolicy` and `Subscription.RedrivePolicy` fields in `generator.yaml`. This makes the generated code use `ackcompare.DocumentEqual()` which performs semantic comparison — parsing both strings as JSON/YAML and comparing the resulting data structures rather than raw strings.

## Changes

- `generator.yaml`: Added `is_document: true` for `Subscription.DeliveryPolicy` and `Subscription.RedrivePolicy`
- `pkg/resource/subscription/delta.go`: Regenerated — now uses `DocumentEqual` instead of `!=` for both fields

## Testing

- `go build -o bin/controller ./cmd/controller` — compiles cleanly
- Existing E2E test (`test_subscription.py`) already validates DeliveryPolicy update flow

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.