### PR TITLE
Mark Topic.DeliveryPolicy as is_document

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-17T01:07:09Z"
-  build_hash: 8b46cc24f655c464e4221f893e710865d7ae600a
+  build_date: "2026-06-19T02:56:55Z"
+  build_hash: 2970ca9b3789515150e27ab80630175a8c77cba4
   go_version: go1.26.0
-  version: v0.59.1-1-g8b46cc2
+  version: v0.59.1-7-g2970ca9
 api_directory_checksum: 33add60999a8cefb3b4acbfe2f6008f5fa6ea52f
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 6b68d67160856c06ea5f168bd16e213d26c8e24f
+  file_checksum: ed8dc3cd5a30bebb03a5015c7229e5704e54b216
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -79,6 +79,7 @@ resources:
         is_attribute: true
       DeliveryPolicy:
         is_attribute: true
+        is_document: true
       DisplayName:
         is_attribute: true
         compare:

--- a/generator.yaml
+++ b/generator.yaml
@@ -79,6 +79,7 @@ resources:
         is_attribute: true
       DeliveryPolicy:
         is_attribute: true
+        is_document: true
       DisplayName:
         is_attribute: true
         compare:

--- a/pkg/resource/topic/delta.go
+++ b/pkg/resource/topic/delta.go
@@ -81,7 +81,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy) {
 		delta.Add("Spec.DeliveryPolicy", a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy)
 	} else if a.ko.Spec.DeliveryPolicy != nil && b.ko.Spec.DeliveryPolicy != nil {
-		if *a.ko.Spec.DeliveryPolicy != *b.ko.Spec.DeliveryPolicy {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.DeliveryPolicy, *b.ko.Spec.DeliveryPolicy); err != nil || !equal {
 			delta.Add("Spec.DeliveryPolicy", a.ko.Spec.DeliveryPolicy, b.ko.Spec.DeliveryPolicy)
 		}
 	}

--- a/test/e2e/resources/topic_simple.yaml
+++ b/test/e2e/resources/topic_simple.yaml
@@ -5,6 +5,8 @@ metadata:
 spec:
   displayName: $DISPLAY_NAME
   name: $TOPIC_NAME
+  deliveryPolicy: |
+    {"http":{"defaultHealthyRetryPolicy":{"minDelayTarget":20,"maxDelayTarget":20,"numRetries":3,"numMaxDelayRetries":0,"numNoDelayRetries":0,"numMinDelayRetries":0,"backoffFunction":"linear"},"disableSubscriptionOverrides":false}}
   tags:
     - key: tag1
       value: val1

--- a/test/e2e/tests/test_topic.py
+++ b/test/e2e/tests/test_topic.py
@@ -177,6 +177,16 @@ class TestTopic:
         assert 'DisplayName' in latest
         assert latest['DisplayName'] == new_display_name
 
+        # Update deliveryPolicy with a different retry configuration to verify
+        # updates work correctly with is_document comparison
+        updated_delivery_policy = '{"http":{"defaultHealthyRetryPolicy":{"minDelayTarget":30,"maxDelayTarget":60,"numRetries":5,"numMaxDelayRetries":2,"numNoDelayRetries":0,"numMinDelayRetries":0,"backoffFunction":"exponential"},"disableSubscriptionOverrides":false}}'
+        updates = {
+            "spec": {"deliveryPolicy": updated_delivery_policy},
+        }
+        k8s.patch_custom_resource(ref, updates)
+        time.sleep(MODIFY_WAIT_AFTER_SECONDS)
+        assert k8s.wait_on_condition(ref, "ACK.ResourceSynced", "True", wait_periods=5)
+
         # Same update code path check for tags...
         latest_tags = topic.get_tags(topic_arn)
         expect_before_update_tags = [


### PR DESCRIPTION
## Summary

Adds is_document: true annotation to Topic.DeliveryPolicy field in generator.yaml.

## Problem

The Topic.DeliveryPolicy field accepts a JSON document configuring message delivery retry behavior. Without the is_document annotation, the controller uses strict string comparison which causes false drift detection and infinite reconciliation loops when the API returns reformatted (but semantically equivalent) JSON.

## Changes

- Added is_document: true to Topic.DeliveryPolicy in generator.yaml
- Regenerated controller code - delta.go now uses DocumentEqual for semantic comparison
- Added deliveryPolicy field to existing topic_simple.yaml test fixture

## Testing

- go build ./cmd/controller - compiles cleanly
- Existing e2e test now exercises the deliveryPolicy field via the updated fixture

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.