### PR TITLE
Add missing cross-resource references

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-22T23:05:50Z"
+  build_date: "2026-06-24T18:34:25Z"
   build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
-  go_version: go1.26.4
+  go_version: go1.26.0
   version: v0.60.0
-api_directory_checksum: 33add60999a8cefb3b4acbfe2f6008f5fa6ea52f
+api_directory_checksum: 687f37e88cec548e073350ad4784944bcf5d6e55
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: ed8dc3cd5a30bebb03a5015c7229e5704e54b216
+  file_checksum: 0e1c824d536fff2ff77083332de430b3288e7037
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -116,34 +116,84 @@ resources:
           is_ignored: true
       HTTPSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       HTTPSuccessFeedbackSampleRate:
         is_attribute: true
       HTTPFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       FirehoseSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       FirehoseSuccessFeedbackSampleRate:
         is_attribute: true
       FirehoseFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       LambdaSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       LambdaSuccessFeedbackSampleRate:
         is_attribute: true
       LambdaFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       ApplicationSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       ApplicationSuccessFeedbackSampleRate:
         is_attribute: true
       ApplicationFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       SQSSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       SQSSuccessFeedbackSampleRate:
         is_attribute: true
       SQSFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
   PlatformApplication:
     is_arn_primary_key: true
     unpack_attributes_map:
@@ -259,6 +309,11 @@ resources:
         is_document: true
       SubscriptionRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       TopicArn:
         references:
           resource: Topic

--- a/apis/v1alpha1/subscription.go
+++ b/apis/v1alpha1/subscription.go
@@ -77,10 +77,11 @@ type SubscriptionSpec struct {
 	//     Firehose delivery stream.
 	//
 	// +kubebuilder:validation:Required
-	Protocol            *string `json:"protocol"`
-	RawMessageDelivery  *string `json:"rawMessageDelivery,omitempty"`
-	RedrivePolicy       *string `json:"redrivePolicy,omitempty"`
-	SubscriptionRoleARN *string `json:"subscriptionRoleARN,omitempty"`
+	Protocol            *string                                  `json:"protocol"`
+	RawMessageDelivery  *string                                  `json:"rawMessageDelivery,omitempty"`
+	RedrivePolicy       *string                                  `json:"redrivePolicy,omitempty"`
+	SubscriptionRoleARN *string                                  `json:"subscriptionRoleARN,omitempty"`
+	SubscriptionRoleRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"subscriptionRoleRef,omitempty"`
 	// The ARN of the topic you want to subscribe to.
 	TopicARN *string                                  `json:"topicARN,omitempty"`
 	TopicRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"topicRef,omitempty"`

--- a/apis/v1alpha1/topic.go
+++ b/apis/v1alpha1/topic.go
@@ -25,10 +25,12 @@ import (
 // A wrapper type for the topic's Amazon Resource Name (ARN). To retrieve a
 // topic's attributes, use GetTopicAttributes.
 type TopicSpec struct {
-	ApplicationFailureFeedbackRoleARN    *string `json:"applicationFailureFeedbackRoleARN,omitempty"`
-	ApplicationSuccessFeedbackRoleARN    *string `json:"applicationSuccessFeedbackRoleARN,omitempty"`
-	ApplicationSuccessFeedbackSampleRate *string `json:"applicationSuccessFeedbackSampleRate,omitempty"`
-	ContentBasedDeduplication            *string `json:"contentBasedDeduplication,omitempty"`
+	ApplicationFailureFeedbackRoleARN    *string                                  `json:"applicationFailureFeedbackRoleARN,omitempty"`
+	ApplicationFailureFeedbackRoleRef    *ackv1alpha1.AWSResourceReferenceWrapper `json:"applicationFailureFeedbackRoleRef,omitempty"`
+	ApplicationSuccessFeedbackRoleARN    *string                                  `json:"applicationSuccessFeedbackRoleARN,omitempty"`
+	ApplicationSuccessFeedbackRoleRef    *ackv1alpha1.AWSResourceReferenceWrapper `json:"applicationSuccessFeedbackRoleRef,omitempty"`
+	ApplicationSuccessFeedbackSampleRate *string                                  `json:"applicationSuccessFeedbackSampleRate,omitempty"`
+	ContentBasedDeduplication            *string                                  `json:"contentBasedDeduplication,omitempty"`
 	// The body of the policy document you want to use for this topic.
 	//
 	// You can only add one policy per topic.
@@ -42,15 +44,21 @@ type TopicSpec struct {
 	FIFOThroughputScope               *string                                  `json:"fifoThroughputScope,omitempty"`
 	FIFOTopic                         *string                                  `json:"fifoTopic,omitempty"`
 	FirehoseFailureFeedbackRoleARN    *string                                  `json:"firehoseFailureFeedbackRoleARN,omitempty"`
+	FirehoseFailureFeedbackRoleRef    *ackv1alpha1.AWSResourceReferenceWrapper `json:"firehoseFailureFeedbackRoleRef,omitempty"`
 	FirehoseSuccessFeedbackRoleARN    *string                                  `json:"firehoseSuccessFeedbackRoleARN,omitempty"`
+	FirehoseSuccessFeedbackRoleRef    *ackv1alpha1.AWSResourceReferenceWrapper `json:"firehoseSuccessFeedbackRoleRef,omitempty"`
 	FirehoseSuccessFeedbackSampleRate *string                                  `json:"firehoseSuccessFeedbackSampleRate,omitempty"`
 	HTTPFailureFeedbackRoleARN        *string                                  `json:"httpFailureFeedbackRoleARN,omitempty"`
+	HTTPFailureFeedbackRoleRef        *ackv1alpha1.AWSResourceReferenceWrapper `json:"httpFailureFeedbackRoleRef,omitempty"`
 	HTTPSuccessFeedbackRoleARN        *string                                  `json:"httpSuccessFeedbackRoleARN,omitempty"`
+	HTTPSuccessFeedbackRoleRef        *ackv1alpha1.AWSResourceReferenceWrapper `json:"httpSuccessFeedbackRoleRef,omitempty"`
 	HTTPSuccessFeedbackSampleRate     *string                                  `json:"httpSuccessFeedbackSampleRate,omitempty"`
 	KMSMasterKeyID                    *string                                  `json:"kmsMasterKeyID,omitempty"`
 	KMSMasterKeyRef                   *ackv1alpha1.AWSResourceReferenceWrapper `json:"kmsMasterKeyRef,omitempty"`
 	LambdaFailureFeedbackRoleARN      *string                                  `json:"lambdaFailureFeedbackRoleARN,omitempty"`
+	LambdaFailureFeedbackRoleRef      *ackv1alpha1.AWSResourceReferenceWrapper `json:"lambdaFailureFeedbackRoleRef,omitempty"`
 	LambdaSuccessFeedbackRoleARN      *string                                  `json:"lambdaSuccessFeedbackRoleARN,omitempty"`
+	LambdaSuccessFeedbackRoleRef      *ackv1alpha1.AWSResourceReferenceWrapper `json:"lambdaSuccessFeedbackRoleRef,omitempty"`
 	LambdaSuccessFeedbackSampleRate   *string                                  `json:"lambdaSuccessFeedbackSampleRate,omitempty"`
 	// The name of the topic you want to create.
 	//
@@ -65,7 +73,9 @@ type TopicSpec struct {
 	Policy                       *string                                  `json:"policy,omitempty"`
 	PolicyRef                    *ackv1alpha1.AWSResourceReferenceWrapper `json:"policyRef,omitempty"`
 	SQSFailureFeedbackRoleARN    *string                                  `json:"sqsFailureFeedbackRoleARN,omitempty"`
+	SQSFailureFeedbackRoleRef    *ackv1alpha1.AWSResourceReferenceWrapper `json:"sqsFailureFeedbackRoleRef,omitempty"`
 	SQSSuccessFeedbackRoleARN    *string                                  `json:"sqsSuccessFeedbackRoleARN,omitempty"`
+	SQSSuccessFeedbackRoleRef    *ackv1alpha1.AWSResourceReferenceWrapper `json:"sqsSuccessFeedbackRoleRef,omitempty"`
 	SQSSuccessFeedbackSampleRate *string                                  `json:"sqsSuccessFeedbackSampleRate,omitempty"`
 	SignatureVersion             *string                                  `json:"signatureVersion,omitempty"`
 	// The list of tags to add to a new topic.

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -643,6 +643,11 @@ func (in *SubscriptionSpec) DeepCopyInto(out *SubscriptionSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SubscriptionRoleRef != nil {
+		in, out := &in.SubscriptionRoleRef, &out.SubscriptionRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.TopicARN != nil {
 		in, out := &in.TopicARN, &out.TopicARN
 		*out = new(string)
@@ -848,10 +853,20 @@ func (in *TopicSpec) DeepCopyInto(out *TopicSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.ApplicationFailureFeedbackRoleRef != nil {
+		in, out := &in.ApplicationFailureFeedbackRoleRef, &out.ApplicationFailureFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.ApplicationSuccessFeedbackRoleARN != nil {
 		in, out := &in.ApplicationSuccessFeedbackRoleARN, &out.ApplicationSuccessFeedbackRoleARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.ApplicationSuccessFeedbackRoleRef != nil {
+		in, out := &in.ApplicationSuccessFeedbackRoleRef, &out.ApplicationSuccessFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.ApplicationSuccessFeedbackSampleRate != nil {
 		in, out := &in.ApplicationSuccessFeedbackSampleRate, &out.ApplicationSuccessFeedbackSampleRate
@@ -893,10 +908,20 @@ func (in *TopicSpec) DeepCopyInto(out *TopicSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.FirehoseFailureFeedbackRoleRef != nil {
+		in, out := &in.FirehoseFailureFeedbackRoleRef, &out.FirehoseFailureFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.FirehoseSuccessFeedbackRoleARN != nil {
 		in, out := &in.FirehoseSuccessFeedbackRoleARN, &out.FirehoseSuccessFeedbackRoleARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.FirehoseSuccessFeedbackRoleRef != nil {
+		in, out := &in.FirehoseSuccessFeedbackRoleRef, &out.FirehoseSuccessFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.FirehoseSuccessFeedbackSampleRate != nil {
 		in, out := &in.FirehoseSuccessFeedbackSampleRate, &out.FirehoseSuccessFeedbackSampleRate
@@ -908,10 +933,20 @@ func (in *TopicSpec) DeepCopyInto(out *TopicSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.HTTPFailureFeedbackRoleRef != nil {
+		in, out := &in.HTTPFailureFeedbackRoleRef, &out.HTTPFailureFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.HTTPSuccessFeedbackRoleARN != nil {
 		in, out := &in.HTTPSuccessFeedbackRoleARN, &out.HTTPSuccessFeedbackRoleARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.HTTPSuccessFeedbackRoleRef != nil {
+		in, out := &in.HTTPSuccessFeedbackRoleRef, &out.HTTPSuccessFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.HTTPSuccessFeedbackSampleRate != nil {
 		in, out := &in.HTTPSuccessFeedbackSampleRate, &out.HTTPSuccessFeedbackSampleRate
@@ -933,10 +968,20 @@ func (in *TopicSpec) DeepCopyInto(out *TopicSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.LambdaFailureFeedbackRoleRef != nil {
+		in, out := &in.LambdaFailureFeedbackRoleRef, &out.LambdaFailureFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.LambdaSuccessFeedbackRoleARN != nil {
 		in, out := &in.LambdaSuccessFeedbackRoleARN, &out.LambdaSuccessFeedbackRoleARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.LambdaSuccessFeedbackRoleRef != nil {
+		in, out := &in.LambdaSuccessFeedbackRoleRef, &out.LambdaSuccessFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.LambdaSuccessFeedbackSampleRate != nil {
 		in, out := &in.LambdaSuccessFeedbackSampleRate, &out.LambdaSuccessFeedbackSampleRate
@@ -963,10 +1008,20 @@ func (in *TopicSpec) DeepCopyInto(out *TopicSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.SQSFailureFeedbackRoleRef != nil {
+		in, out := &in.SQSFailureFeedbackRoleRef, &out.SQSFailureFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.SQSSuccessFeedbackRoleARN != nil {
 		in, out := &in.SQSSuccessFeedbackRoleARN, &out.SQSSuccessFeedbackRoleARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.SQSSuccessFeedbackRoleRef != nil {
+		in, out := &in.SQSSuccessFeedbackRoleRef, &out.SQSSuccessFeedbackRoleRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.SQSSuccessFeedbackSampleRate != nil {
 		in, out := &in.SQSSuccessFeedbackSampleRate, &out.SQSSuccessFeedbackSampleRate

--- a/config/crd/bases/sns.services.k8s.aws_subscriptions.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_subscriptions.yaml
@@ -119,6 +119,23 @@ spec:
                 type: string
               subscriptionRoleARN:
                 type: string
+              subscriptionRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               topicARN:
                 description: The ARN of the topic you want to subscribe to.
                 type: string

--- a/config/crd/bases/sns.services.k8s.aws_topics.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_topics.yaml
@@ -59,8 +59,42 @@ spec:
             properties:
               applicationFailureFeedbackRoleARN:
                 type: string
+              applicationFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               applicationSuccessFeedbackRoleARN:
                 type: string
+              applicationSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               applicationSuccessFeedbackSampleRate:
                 type: string
               contentBasedDeduplication:
@@ -85,14 +119,82 @@ spec:
                 type: string
               firehoseFailureFeedbackRoleARN:
                 type: string
+              firehoseFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               firehoseSuccessFeedbackRoleARN:
                 type: string
+              firehoseSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               firehoseSuccessFeedbackSampleRate:
                 type: string
               httpFailureFeedbackRoleARN:
                 type: string
+              httpFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               httpSuccessFeedbackRoleARN:
                 type: string
+              httpSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               httpSuccessFeedbackSampleRate:
                 type: string
               kmsMasterKeyID:
@@ -116,8 +218,42 @@ spec:
                 type: object
               lambdaFailureFeedbackRoleARN:
                 type: string
+              lambdaFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               lambdaSuccessFeedbackRoleARN:
                 type: string
+              lambdaSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               lambdaSuccessFeedbackSampleRate:
                 type: string
               name:
@@ -156,8 +292,42 @@ spec:
                 type: string
               sqsFailureFeedbackRoleARN:
                 type: string
+              sqsFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               sqsSuccessFeedbackRoleARN:
                 type: string
+              sqsSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               sqsSuccessFeedbackSampleRate:
                 type: string
               tags:

--- a/generator.yaml
+++ b/generator.yaml
@@ -116,34 +116,84 @@ resources:
           is_ignored: true
       HTTPSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       HTTPSuccessFeedbackSampleRate:
         is_attribute: true
       HTTPFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       FirehoseSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       FirehoseSuccessFeedbackSampleRate:
         is_attribute: true
       FirehoseFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       LambdaSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       LambdaSuccessFeedbackSampleRate:
         is_attribute: true
       LambdaFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       ApplicationSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       ApplicationSuccessFeedbackSampleRate:
         is_attribute: true
       ApplicationFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       SQSSuccessFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       SQSSuccessFeedbackSampleRate:
         is_attribute: true
       SQSFailureFeedbackRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
   PlatformApplication:
     is_arn_primary_key: true
     unpack_attributes_map:
@@ -259,6 +309,11 @@ resources:
         is_document: true
       SubscriptionRoleArn:
         is_attribute: true
+        type: string
+        references:
+          service_name: iam
+          resource: Role
+          path: Status.ACKResourceMetadata.ARN
       TopicArn:
         references:
           resource: Topic

--- a/helm/crds/sns.services.k8s.aws_subscriptions.yaml
+++ b/helm/crds/sns.services.k8s.aws_subscriptions.yaml
@@ -119,6 +119,23 @@ spec:
                 type: string
               subscriptionRoleARN:
                 type: string
+              subscriptionRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               topicARN:
                 description: The ARN of the topic you want to subscribe to.
                 type: string

--- a/helm/crds/sns.services.k8s.aws_topics.yaml
+++ b/helm/crds/sns.services.k8s.aws_topics.yaml
@@ -59,8 +59,42 @@ spec:
             properties:
               applicationFailureFeedbackRoleARN:
                 type: string
+              applicationFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               applicationSuccessFeedbackRoleARN:
                 type: string
+              applicationSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               applicationSuccessFeedbackSampleRate:
                 type: string
               contentBasedDeduplication:
@@ -85,14 +119,82 @@ spec:
                 type: string
               firehoseFailureFeedbackRoleARN:
                 type: string
+              firehoseFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               firehoseSuccessFeedbackRoleARN:
                 type: string
+              firehoseSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               firehoseSuccessFeedbackSampleRate:
                 type: string
               httpFailureFeedbackRoleARN:
                 type: string
+              httpFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               httpSuccessFeedbackRoleARN:
                 type: string
+              httpSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               httpSuccessFeedbackSampleRate:
                 type: string
               kmsMasterKeyID:
@@ -116,8 +218,42 @@ spec:
                 type: object
               lambdaFailureFeedbackRoleARN:
                 type: string
+              lambdaFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               lambdaSuccessFeedbackRoleARN:
                 type: string
+              lambdaSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               lambdaSuccessFeedbackSampleRate:
                 type: string
               name:
@@ -156,8 +292,42 @@ spec:
                 type: string
               sqsFailureFeedbackRoleARN:
                 type: string
+              sqsFailureFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               sqsSuccessFeedbackRoleARN:
                 type: string
+              sqsSuccessFeedbackRoleRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               sqsSuccessFeedbackSampleRate:
                 type: string
               tags:

--- a/pkg/resource/subscription/delta.go
+++ b/pkg/resource/subscription/delta.go
@@ -99,6 +99,9 @@ func newResourceDelta(
 			delta.Add("Spec.SubscriptionRoleARN", a.ko.Spec.SubscriptionRoleARN, b.ko.Spec.SubscriptionRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SubscriptionRoleRef, b.ko.Spec.SubscriptionRoleRef) {
+		delta.Add("Spec.SubscriptionRoleRef", a.ko.Spec.SubscriptionRoleRef, b.ko.Spec.SubscriptionRoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.TopicARN, b.ko.Spec.TopicARN) {
 		delta.Add("Spec.TopicARN", a.ko.Spec.TopicARN, b.ko.Spec.TopicARN)
 	} else if a.ko.Spec.TopicARN != nil && b.ko.Spec.TopicARN != nil {

--- a/pkg/resource/subscription/references.go
+++ b/pkg/resource/subscription/references.go
@@ -23,6 +23,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	iamapitypes "github.com/aws-controllers-k8s/iam-controller/apis/v1alpha1"
 	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
 	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
@@ -31,12 +32,19 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1"
 )
 
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
 // contains the original *Ref values, but none of their respective concrete
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.SubscriptionRoleRef != nil {
+		ko.Spec.SubscriptionRoleARN = nil
+	}
 
 	if ko.Spec.TopicRef != nil {
 		ko.Spec.TopicARN = nil
@@ -61,6 +69,12 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForSubscriptionRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForTopicARN(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -74,11 +88,106 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Subscription) error {
 
+	if ko.Spec.SubscriptionRoleRef != nil && ko.Spec.SubscriptionRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SubscriptionRoleARN", "SubscriptionRoleRef")
+	}
+
 	if ko.Spec.TopicRef != nil && ko.Spec.TopicARN != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("TopicARN", "TopicRef")
 	}
 	if ko.Spec.TopicRef == nil && ko.Spec.TopicARN == nil {
 		return ackerr.ResourceReferenceOrIDRequiredFor("TopicARN", "TopicRef")
+	}
+	return nil
+}
+
+// resolveReferenceForSubscriptionRoleARN reads the resource referenced
+// from SubscriptionRoleRef field and sets the SubscriptionRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSubscriptionRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Subscription,
+) (hasReferences bool, err error) {
+	if ko.Spec.SubscriptionRoleRef != nil && ko.Spec.SubscriptionRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.SubscriptionRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SubscriptionRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.SubscriptionRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
 	}
 	return nil
 }

--- a/pkg/resource/topic/delta.go
+++ b/pkg/resource/topic/delta.go
@@ -50,12 +50,18 @@ func newResourceDelta(
 			delta.Add("Spec.ApplicationFailureFeedbackRoleARN", a.ko.Spec.ApplicationFailureFeedbackRoleARN, b.ko.Spec.ApplicationFailureFeedbackRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.ApplicationFailureFeedbackRoleRef, b.ko.Spec.ApplicationFailureFeedbackRoleRef) {
+		delta.Add("Spec.ApplicationFailureFeedbackRoleRef", a.ko.Spec.ApplicationFailureFeedbackRoleRef, b.ko.Spec.ApplicationFailureFeedbackRoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ApplicationSuccessFeedbackRoleARN, b.ko.Spec.ApplicationSuccessFeedbackRoleARN) {
 		delta.Add("Spec.ApplicationSuccessFeedbackRoleARN", a.ko.Spec.ApplicationSuccessFeedbackRoleARN, b.ko.Spec.ApplicationSuccessFeedbackRoleARN)
 	} else if a.ko.Spec.ApplicationSuccessFeedbackRoleARN != nil && b.ko.Spec.ApplicationSuccessFeedbackRoleARN != nil {
 		if *a.ko.Spec.ApplicationSuccessFeedbackRoleARN != *b.ko.Spec.ApplicationSuccessFeedbackRoleARN {
 			delta.Add("Spec.ApplicationSuccessFeedbackRoleARN", a.ko.Spec.ApplicationSuccessFeedbackRoleARN, b.ko.Spec.ApplicationSuccessFeedbackRoleARN)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.ApplicationSuccessFeedbackRoleRef, b.ko.Spec.ApplicationSuccessFeedbackRoleRef) {
+		delta.Add("Spec.ApplicationSuccessFeedbackRoleRef", a.ko.Spec.ApplicationSuccessFeedbackRoleRef, b.ko.Spec.ApplicationSuccessFeedbackRoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.ApplicationSuccessFeedbackSampleRate, b.ko.Spec.ApplicationSuccessFeedbackSampleRate) {
 		delta.Add("Spec.ApplicationSuccessFeedbackSampleRate", a.ko.Spec.ApplicationSuccessFeedbackSampleRate, b.ko.Spec.ApplicationSuccessFeedbackSampleRate)
@@ -115,12 +121,18 @@ func newResourceDelta(
 			delta.Add("Spec.FirehoseFailureFeedbackRoleARN", a.ko.Spec.FirehoseFailureFeedbackRoleARN, b.ko.Spec.FirehoseFailureFeedbackRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.FirehoseFailureFeedbackRoleRef, b.ko.Spec.FirehoseFailureFeedbackRoleRef) {
+		delta.Add("Spec.FirehoseFailureFeedbackRoleRef", a.ko.Spec.FirehoseFailureFeedbackRoleRef, b.ko.Spec.FirehoseFailureFeedbackRoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.FirehoseSuccessFeedbackRoleARN, b.ko.Spec.FirehoseSuccessFeedbackRoleARN) {
 		delta.Add("Spec.FirehoseSuccessFeedbackRoleARN", a.ko.Spec.FirehoseSuccessFeedbackRoleARN, b.ko.Spec.FirehoseSuccessFeedbackRoleARN)
 	} else if a.ko.Spec.FirehoseSuccessFeedbackRoleARN != nil && b.ko.Spec.FirehoseSuccessFeedbackRoleARN != nil {
 		if *a.ko.Spec.FirehoseSuccessFeedbackRoleARN != *b.ko.Spec.FirehoseSuccessFeedbackRoleARN {
 			delta.Add("Spec.FirehoseSuccessFeedbackRoleARN", a.ko.Spec.FirehoseSuccessFeedbackRoleARN, b.ko.Spec.FirehoseSuccessFeedbackRoleARN)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.FirehoseSuccessFeedbackRoleRef, b.ko.Spec.FirehoseSuccessFeedbackRoleRef) {
+		delta.Add("Spec.FirehoseSuccessFeedbackRoleRef", a.ko.Spec.FirehoseSuccessFeedbackRoleRef, b.ko.Spec.FirehoseSuccessFeedbackRoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.FirehoseSuccessFeedbackSampleRate, b.ko.Spec.FirehoseSuccessFeedbackSampleRate) {
 		delta.Add("Spec.FirehoseSuccessFeedbackSampleRate", a.ko.Spec.FirehoseSuccessFeedbackSampleRate, b.ko.Spec.FirehoseSuccessFeedbackSampleRate)
@@ -136,12 +148,18 @@ func newResourceDelta(
 			delta.Add("Spec.HTTPFailureFeedbackRoleARN", a.ko.Spec.HTTPFailureFeedbackRoleARN, b.ko.Spec.HTTPFailureFeedbackRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.HTTPFailureFeedbackRoleRef, b.ko.Spec.HTTPFailureFeedbackRoleRef) {
+		delta.Add("Spec.HTTPFailureFeedbackRoleRef", a.ko.Spec.HTTPFailureFeedbackRoleRef, b.ko.Spec.HTTPFailureFeedbackRoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.HTTPSuccessFeedbackRoleARN, b.ko.Spec.HTTPSuccessFeedbackRoleARN) {
 		delta.Add("Spec.HTTPSuccessFeedbackRoleARN", a.ko.Spec.HTTPSuccessFeedbackRoleARN, b.ko.Spec.HTTPSuccessFeedbackRoleARN)
 	} else if a.ko.Spec.HTTPSuccessFeedbackRoleARN != nil && b.ko.Spec.HTTPSuccessFeedbackRoleARN != nil {
 		if *a.ko.Spec.HTTPSuccessFeedbackRoleARN != *b.ko.Spec.HTTPSuccessFeedbackRoleARN {
 			delta.Add("Spec.HTTPSuccessFeedbackRoleARN", a.ko.Spec.HTTPSuccessFeedbackRoleARN, b.ko.Spec.HTTPSuccessFeedbackRoleARN)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.HTTPSuccessFeedbackRoleRef, b.ko.Spec.HTTPSuccessFeedbackRoleRef) {
+		delta.Add("Spec.HTTPSuccessFeedbackRoleRef", a.ko.Spec.HTTPSuccessFeedbackRoleRef, b.ko.Spec.HTTPSuccessFeedbackRoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.HTTPSuccessFeedbackSampleRate, b.ko.Spec.HTTPSuccessFeedbackSampleRate) {
 		delta.Add("Spec.HTTPSuccessFeedbackSampleRate", a.ko.Spec.HTTPSuccessFeedbackSampleRate, b.ko.Spec.HTTPSuccessFeedbackSampleRate)
@@ -167,12 +185,18 @@ func newResourceDelta(
 			delta.Add("Spec.LambdaFailureFeedbackRoleARN", a.ko.Spec.LambdaFailureFeedbackRoleARN, b.ko.Spec.LambdaFailureFeedbackRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.LambdaFailureFeedbackRoleRef, b.ko.Spec.LambdaFailureFeedbackRoleRef) {
+		delta.Add("Spec.LambdaFailureFeedbackRoleRef", a.ko.Spec.LambdaFailureFeedbackRoleRef, b.ko.Spec.LambdaFailureFeedbackRoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.LambdaSuccessFeedbackRoleARN, b.ko.Spec.LambdaSuccessFeedbackRoleARN) {
 		delta.Add("Spec.LambdaSuccessFeedbackRoleARN", a.ko.Spec.LambdaSuccessFeedbackRoleARN, b.ko.Spec.LambdaSuccessFeedbackRoleARN)
 	} else if a.ko.Spec.LambdaSuccessFeedbackRoleARN != nil && b.ko.Spec.LambdaSuccessFeedbackRoleARN != nil {
 		if *a.ko.Spec.LambdaSuccessFeedbackRoleARN != *b.ko.Spec.LambdaSuccessFeedbackRoleARN {
 			delta.Add("Spec.LambdaSuccessFeedbackRoleARN", a.ko.Spec.LambdaSuccessFeedbackRoleARN, b.ko.Spec.LambdaSuccessFeedbackRoleARN)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.LambdaSuccessFeedbackRoleRef, b.ko.Spec.LambdaSuccessFeedbackRoleRef) {
+		delta.Add("Spec.LambdaSuccessFeedbackRoleRef", a.ko.Spec.LambdaSuccessFeedbackRoleRef, b.ko.Spec.LambdaSuccessFeedbackRoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.LambdaSuccessFeedbackSampleRate, b.ko.Spec.LambdaSuccessFeedbackSampleRate) {
 		delta.Add("Spec.LambdaSuccessFeedbackSampleRate", a.ko.Spec.LambdaSuccessFeedbackSampleRate, b.ko.Spec.LambdaSuccessFeedbackSampleRate)
@@ -205,12 +229,18 @@ func newResourceDelta(
 			delta.Add("Spec.SQSFailureFeedbackRoleARN", a.ko.Spec.SQSFailureFeedbackRoleARN, b.ko.Spec.SQSFailureFeedbackRoleARN)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SQSFailureFeedbackRoleRef, b.ko.Spec.SQSFailureFeedbackRoleRef) {
+		delta.Add("Spec.SQSFailureFeedbackRoleRef", a.ko.Spec.SQSFailureFeedbackRoleRef, b.ko.Spec.SQSFailureFeedbackRoleRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SQSSuccessFeedbackRoleARN, b.ko.Spec.SQSSuccessFeedbackRoleARN) {
 		delta.Add("Spec.SQSSuccessFeedbackRoleARN", a.ko.Spec.SQSSuccessFeedbackRoleARN, b.ko.Spec.SQSSuccessFeedbackRoleARN)
 	} else if a.ko.Spec.SQSSuccessFeedbackRoleARN != nil && b.ko.Spec.SQSSuccessFeedbackRoleARN != nil {
 		if *a.ko.Spec.SQSSuccessFeedbackRoleARN != *b.ko.Spec.SQSSuccessFeedbackRoleARN {
 			delta.Add("Spec.SQSSuccessFeedbackRoleARN", a.ko.Spec.SQSSuccessFeedbackRoleARN, b.ko.Spec.SQSSuccessFeedbackRoleARN)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.SQSSuccessFeedbackRoleRef, b.ko.Spec.SQSSuccessFeedbackRoleRef) {
+		delta.Add("Spec.SQSSuccessFeedbackRoleRef", a.ko.Spec.SQSSuccessFeedbackRoleRef, b.ko.Spec.SQSSuccessFeedbackRoleRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.SQSSuccessFeedbackSampleRate, b.ko.Spec.SQSSuccessFeedbackSampleRate) {
 		delta.Add("Spec.SQSSuccessFeedbackSampleRate", a.ko.Spec.SQSSuccessFeedbackSampleRate, b.ko.Spec.SQSSuccessFeedbackSampleRate)

--- a/pkg/resource/topic/references.go
+++ b/pkg/resource/topic/references.go
@@ -33,11 +33,41 @@ import (
 	svcapitypes "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1"
 )
 
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys,verbs=get;list
 // +kubebuilder:rbac:groups=kms.services.k8s.aws,resources=keys/status,verbs=get;list
 
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=policies,verbs=get;list
 // +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=policies/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
+
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles,verbs=get;list
+// +kubebuilder:rbac:groups=iam.services.k8s.aws,resources=roles/status,verbs=get;list
 
 // ClearResolvedReferences removes any reference values that were made
 // concrete in the spec. It returns a copy of the input AWSResource which
@@ -46,12 +76,52 @@ import (
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
 
+	if ko.Spec.ApplicationFailureFeedbackRoleRef != nil {
+		ko.Spec.ApplicationFailureFeedbackRoleARN = nil
+	}
+
+	if ko.Spec.ApplicationSuccessFeedbackRoleRef != nil {
+		ko.Spec.ApplicationSuccessFeedbackRoleARN = nil
+	}
+
+	if ko.Spec.FirehoseFailureFeedbackRoleRef != nil {
+		ko.Spec.FirehoseFailureFeedbackRoleARN = nil
+	}
+
+	if ko.Spec.FirehoseSuccessFeedbackRoleRef != nil {
+		ko.Spec.FirehoseSuccessFeedbackRoleARN = nil
+	}
+
+	if ko.Spec.HTTPFailureFeedbackRoleRef != nil {
+		ko.Spec.HTTPFailureFeedbackRoleARN = nil
+	}
+
+	if ko.Spec.HTTPSuccessFeedbackRoleRef != nil {
+		ko.Spec.HTTPSuccessFeedbackRoleARN = nil
+	}
+
 	if ko.Spec.KMSMasterKeyRef != nil {
 		ko.Spec.KMSMasterKeyID = nil
 	}
 
+	if ko.Spec.LambdaFailureFeedbackRoleRef != nil {
+		ko.Spec.LambdaFailureFeedbackRoleARN = nil
+	}
+
+	if ko.Spec.LambdaSuccessFeedbackRoleRef != nil {
+		ko.Spec.LambdaSuccessFeedbackRoleARN = nil
+	}
+
 	if ko.Spec.PolicyRef != nil {
 		ko.Spec.Policy = nil
+	}
+
+	if ko.Spec.SQSFailureFeedbackRoleRef != nil {
+		ko.Spec.SQSFailureFeedbackRoleARN = nil
+	}
+
+	if ko.Spec.SQSSuccessFeedbackRoleRef != nil {
+		ko.Spec.SQSSuccessFeedbackRoleARN = nil
 	}
 
 	return &resource{ko}
@@ -73,13 +143,73 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForApplicationFailureFeedbackRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForApplicationSuccessFeedbackRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForFirehoseFailureFeedbackRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForFirehoseSuccessFeedbackRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForHTTPFailureFeedbackRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForHTTPSuccessFeedbackRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForKMSMasterKeyID(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
 	}
 
+	if fieldHasReferences, err := rm.resolveReferenceForLambdaFailureFeedbackRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForLambdaSuccessFeedbackRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForPolicy(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForSQSFailureFeedbackRoleARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	if fieldHasReferences, err := rm.resolveReferenceForSQSSuccessFeedbackRoleARN(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
 		resourceHasReferences = resourceHasReferences || fieldHasReferences
@@ -92,14 +222,330 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.Topic) error {
 
+	if ko.Spec.ApplicationFailureFeedbackRoleRef != nil && ko.Spec.ApplicationFailureFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ApplicationFailureFeedbackRoleARN", "ApplicationFailureFeedbackRoleRef")
+	}
+
+	if ko.Spec.ApplicationSuccessFeedbackRoleRef != nil && ko.Spec.ApplicationSuccessFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("ApplicationSuccessFeedbackRoleARN", "ApplicationSuccessFeedbackRoleRef")
+	}
+
+	if ko.Spec.FirehoseFailureFeedbackRoleRef != nil && ko.Spec.FirehoseFailureFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("FirehoseFailureFeedbackRoleARN", "FirehoseFailureFeedbackRoleRef")
+	}
+
+	if ko.Spec.FirehoseSuccessFeedbackRoleRef != nil && ko.Spec.FirehoseSuccessFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("FirehoseSuccessFeedbackRoleARN", "FirehoseSuccessFeedbackRoleRef")
+	}
+
+	if ko.Spec.HTTPFailureFeedbackRoleRef != nil && ko.Spec.HTTPFailureFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("HTTPFailureFeedbackRoleARN", "HTTPFailureFeedbackRoleRef")
+	}
+
+	if ko.Spec.HTTPSuccessFeedbackRoleRef != nil && ko.Spec.HTTPSuccessFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("HTTPSuccessFeedbackRoleARN", "HTTPSuccessFeedbackRoleRef")
+	}
+
 	if ko.Spec.KMSMasterKeyRef != nil && ko.Spec.KMSMasterKeyID != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("KMSMasterKeyID", "KMSMasterKeyRef")
+	}
+
+	if ko.Spec.LambdaFailureFeedbackRoleRef != nil && ko.Spec.LambdaFailureFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("LambdaFailureFeedbackRoleARN", "LambdaFailureFeedbackRoleRef")
+	}
+
+	if ko.Spec.LambdaSuccessFeedbackRoleRef != nil && ko.Spec.LambdaSuccessFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("LambdaSuccessFeedbackRoleARN", "LambdaSuccessFeedbackRoleRef")
 	}
 
 	if ko.Spec.PolicyRef != nil && ko.Spec.Policy != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("Policy", "PolicyRef")
 	}
+
+	if ko.Spec.SQSFailureFeedbackRoleRef != nil && ko.Spec.SQSFailureFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SQSFailureFeedbackRoleARN", "SQSFailureFeedbackRoleRef")
+	}
+
+	if ko.Spec.SQSSuccessFeedbackRoleRef != nil && ko.Spec.SQSSuccessFeedbackRoleARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("SQSSuccessFeedbackRoleARN", "SQSSuccessFeedbackRoleRef")
+	}
 	return nil
+}
+
+// resolveReferenceForApplicationFailureFeedbackRoleARN reads the resource referenced
+// from ApplicationFailureFeedbackRoleRef field and sets the ApplicationFailureFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForApplicationFailureFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.ApplicationFailureFeedbackRoleRef != nil && ko.Spec.ApplicationFailureFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.ApplicationFailureFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ApplicationFailureFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.ApplicationFailureFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_Role looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_Role(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *iamapitypes.Role,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"Role",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"Role",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"Role",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"Role",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
+	return nil
+}
+
+// resolveReferenceForApplicationSuccessFeedbackRoleARN reads the resource referenced
+// from ApplicationSuccessFeedbackRoleRef field and sets the ApplicationSuccessFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForApplicationSuccessFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.ApplicationSuccessFeedbackRoleRef != nil && ko.Spec.ApplicationSuccessFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.ApplicationSuccessFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: ApplicationSuccessFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.ApplicationSuccessFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// resolveReferenceForFirehoseFailureFeedbackRoleARN reads the resource referenced
+// from FirehoseFailureFeedbackRoleRef field and sets the FirehoseFailureFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForFirehoseFailureFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.FirehoseFailureFeedbackRoleRef != nil && ko.Spec.FirehoseFailureFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.FirehoseFailureFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: FirehoseFailureFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.FirehoseFailureFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// resolveReferenceForFirehoseSuccessFeedbackRoleARN reads the resource referenced
+// from FirehoseSuccessFeedbackRoleRef field and sets the FirehoseSuccessFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForFirehoseSuccessFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.FirehoseSuccessFeedbackRoleRef != nil && ko.Spec.FirehoseSuccessFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.FirehoseSuccessFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: FirehoseSuccessFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.FirehoseSuccessFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// resolveReferenceForHTTPFailureFeedbackRoleARN reads the resource referenced
+// from HTTPFailureFeedbackRoleRef field and sets the HTTPFailureFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForHTTPFailureFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.HTTPFailureFeedbackRoleRef != nil && ko.Spec.HTTPFailureFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.HTTPFailureFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: HTTPFailureFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.HTTPFailureFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// resolveReferenceForHTTPSuccessFeedbackRoleARN reads the resource referenced
+// from HTTPSuccessFeedbackRoleRef field and sets the HTTPSuccessFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForHTTPSuccessFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.HTTPSuccessFeedbackRoleRef != nil && ko.Spec.HTTPSuccessFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.HTTPSuccessFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: HTTPSuccessFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.HTTPSuccessFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
 }
 
 // resolveReferenceForKMSMasterKeyID reads the resource referenced
@@ -193,6 +639,80 @@ func getReferencedResourceState_Key(
 	return nil
 }
 
+// resolveReferenceForLambdaFailureFeedbackRoleARN reads the resource referenced
+// from LambdaFailureFeedbackRoleRef field and sets the LambdaFailureFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForLambdaFailureFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.LambdaFailureFeedbackRoleRef != nil && ko.Spec.LambdaFailureFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.LambdaFailureFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: LambdaFailureFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.LambdaFailureFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// resolveReferenceForLambdaSuccessFeedbackRoleARN reads the resource referenced
+// from LambdaSuccessFeedbackRoleRef field and sets the LambdaSuccessFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForLambdaSuccessFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.LambdaSuccessFeedbackRoleRef != nil && ko.Spec.LambdaSuccessFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.LambdaSuccessFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: LambdaSuccessFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.LambdaSuccessFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
 // resolveReferenceForPolicy reads the resource referenced
 // from PolicyRef field and sets the Policy
 // from referenced resource. Returns a boolean indicating whether a reference
@@ -282,4 +802,78 @@ func getReferencedResourceState_Policy(
 			"Spec.PolicyDocument")
 	}
 	return nil
+}
+
+// resolveReferenceForSQSFailureFeedbackRoleARN reads the resource referenced
+// from SQSFailureFeedbackRoleRef field and sets the SQSFailureFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSQSFailureFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.SQSFailureFeedbackRoleRef != nil && ko.Spec.SQSFailureFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.SQSFailureFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SQSFailureFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.SQSFailureFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// resolveReferenceForSQSSuccessFeedbackRoleARN reads the resource referenced
+// from SQSSuccessFeedbackRoleRef field and sets the SQSSuccessFeedbackRoleARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForSQSSuccessFeedbackRoleARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.Topic,
+) (hasReferences bool, err error) {
+	if ko.Spec.SQSSuccessFeedbackRoleRef != nil && ko.Spec.SQSSuccessFeedbackRoleRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.SQSSuccessFeedbackRoleRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: SQSSuccessFeedbackRoleRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &iamapitypes.Role{}
+		if err := getReferencedResourceState_Role(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.SQSSuccessFeedbackRoleARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
 }


### PR DESCRIPTION
Description of changes:
Adds cross-resource references for ARN fields that were previously plain strings, allowing them to be resolved from other ACK resources via `*Ref` fields.

| Resource | Field | Target |
| --- | --- | --- |
| Topic | httpSuccessFeedbackRoleARN, httpFailureFeedbackRoleARN, firehoseSuccessFeedbackRoleARN, firehoseFailureFeedbackRoleARN, lambdaSuccessFeedbackRoleARN, lambdaFailureFeedbackRoleARN, applicationSuccessFeedbackRoleARN, applicationFailureFeedbackRoleARN, sqsSuccessFeedbackRoleARN, sqsFailureFeedbackRoleARN | iam/Role |
| Subscription | subscriptionRoleARN | iam/Role |

These mirror existing reference patterns already in the controller (e.g. `successFeedbackRoleARN`/`failureFeedbackRoleARN` on PlatformApplication -> iam/Role, and `eventEndpointCreated/Deleted/Updated` -> sns/Topic).

Generated with code-generator `v0.60.0` / runtime `v0.60.0`, `AWS_SDK_GO_VERSION=v1.34.0`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.