### PR TITLE
[sns-controller] Treat Topic DataProtectionPolicy as a document

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-06-24T18:34:25Z"
-  build_hash: 2ae5d2cfadaa2a10b2ccb9e73a111b2a91c36642
+  build_date: "2026-07-02T20:06:06Z"
+  build_hash: 84c9b9904125e2182619e048d7e35d0f8700d20c
   go_version: go1.26.0
-  version: v0.60.0
-api_directory_checksum: 687f37e88cec548e073350ad4784944bcf5d6e55
+  version: v0.60.0-3-g84c9b99
+api_directory_checksum: 3560bd69253be24ef75e5d0b16aa8fc538946d40
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: 0e1c824d536fff2ff77083332de430b3288e7037
+  file_checksum: d6057746088e3ced93cefc5c17651a76131108bb
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -77,6 +77,8 @@ resources:
         is_attribute: true
       TracingConfig:
         is_attribute: true
+      DataProtectionPolicy:
+        is_document: true
       DeliveryPolicy:
         is_attribute: true
         is_document: true

--- a/generator.yaml
+++ b/generator.yaml
@@ -77,6 +77,8 @@ resources:
         is_attribute: true
       TracingConfig:
         is_attribute: true
+      DataProtectionPolicy:
+        is_document: true
       DeliveryPolicy:
         is_attribute: true
         is_document: true

--- a/pkg/resource/topic/delta.go
+++ b/pkg/resource/topic/delta.go
@@ -80,7 +80,7 @@ func newResourceDelta(
 	if ackcompare.HasNilDifference(a.ko.Spec.DataProtectionPolicy, b.ko.Spec.DataProtectionPolicy) {
 		delta.Add("Spec.DataProtectionPolicy", a.ko.Spec.DataProtectionPolicy, b.ko.Spec.DataProtectionPolicy)
 	} else if a.ko.Spec.DataProtectionPolicy != nil && b.ko.Spec.DataProtectionPolicy != nil {
-		if *a.ko.Spec.DataProtectionPolicy != *b.ko.Spec.DataProtectionPolicy {
+		if equal, err := ackcompare.DocumentEqual(*a.ko.Spec.DataProtectionPolicy, *b.ko.Spec.DataProtectionPolicy); err != nil || !equal {
 			delta.Add("Spec.DataProtectionPolicy", a.ko.Spec.DataProtectionPolicy, b.ko.Spec.DataProtectionPolicy)
 		}
 	}


### PR DESCRIPTION
## Description

Mark the Topic `DataProtectionPolicy` field as `is_document` in `generator.yaml`.

### Changes
- **generator.yaml**: Add `DataProtectionPolicy: is_document: true` under the `Topic` resource fields.
- **Generated code** (`pkg/resource/topic/delta.go`): The delta comparison now uses `ackcompare.DocumentEqual` for semantic JSON comparison instead of raw string equality. This prevents spurious diffs when SNS returns a semantically equivalent but differently formatted policy document.
- **E2E tests**: Added create + update coverage for `dataProtectionPolicy` in the simple topic test, plus a `get_data_protection_policy` helper.

### Testing
- `make build-controller` (SERVICE=sns, AWS_SDK_GO_VERSION=v1.34.0) succeeds
- `go build -o bin/controller ./cmd/controller` compiles cleanly
- E2E test files parse and follow the existing `deliveryPolicy` document-field pattern

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.