### PR TITLE
fix(Subscription): requeue when PendingConfirmation is true

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -7,7 +7,7 @@ api_directory_checksum: 3560bd69253be24ef75e5d0b16aa8fc538946d40
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: d6057746088e3ced93cefc5c17651a76131108bb
+  file_checksum: 41f70a98156de30a5f012eed96b2bbb4dbed98b5
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -278,6 +278,8 @@ resources:
         template_path: hooks/subscription/sdk_create_post_build_request.go.tpl
       sdk_get_attributes_pre_set_output:
         template_path: hooks/subscription/sdk_get_attributes_pre_set_output.go.tpl
+      sdk_get_attributes_post_set_output:
+        template_path: hooks/subscription/sdk_get_attributes_post_set_output.go.tpl
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
     fields:

--- a/generator.yaml
+++ b/generator.yaml
@@ -278,6 +278,8 @@ resources:
         template_path: hooks/subscription/sdk_create_post_build_request.go.tpl
       sdk_get_attributes_pre_set_output:
         template_path: hooks/subscription/sdk_get_attributes_pre_set_output.go.tpl
+      sdk_get_attributes_post_set_output:
+        template_path: hooks/subscription/sdk_get_attributes_post_set_output.go.tpl
       delta_pre_compare:
         code: customPreCompare(delta, a, b)
     fields:

--- a/pkg/resource/subscription/hooks.go
+++ b/pkg/resource/subscription/hooks.go
@@ -16,13 +16,15 @@ package subscription
 import (
 	"context"
 	"errors"
-
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
+	ackcondition "github.com/aws-controllers-k8s/runtime/pkg/condition"
 	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrequeue "github.com/aws-controllers-k8s/runtime/pkg/requeue"
 	ackrtlog "github.com/aws-controllers-k8s/runtime/pkg/runtime/log"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	svcsdk "github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/aws/smithy-go"
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
@@ -76,6 +78,16 @@ func (rm *resourceManager) customUpdate(
 
 	ko := desired.ko.DeepCopy()
 	rm.setStatusDefaults(ko)
+
+	// If subscription is pending confirmation, requeue after 1 minute
+	// to detect when the endpoint owner confirms the subscription.
+	if ko.Status.PendingConfirmation != nil && *ko.Status.PendingConfirmation == "true" {
+		msg := "Subscription is pending confirmation from the endpoint owner"
+		res := &resource{ko}
+		ackcondition.SetSynced(res, corev1.ConditionFalse, &msg, nil)
+		return res, ackrequeue.NeededAfter(nil, ackrequeue.DefaultRequeueAfterDuration)
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/pkg/resource/subscription/sdk.go
+++ b/pkg/resource/subscription/sdk.go
@@ -163,6 +163,18 @@ func (rm *resourceManager) sdkFind(
 	}
 
 	rm.setStatusDefaults(ko)
+	// If the subscription is pending confirmation (HTTP/HTTPS protocol),
+	// set Synced=False so the ACK reconciler requeues to detect when the
+	// endpoint owner confirms. Without this, the controller would not
+	// re-examine the subscription until the next full resync (~10 hours).
+	res := &resource{ko}
+	if ko.Status.PendingConfirmation != nil && *ko.Status.PendingConfirmation == "true" {
+		msg := "Subscription is pending confirmation from the endpoint owner"
+		ackcondition.SetSynced(res, corev1.ConditionFalse, &msg, nil)
+	} else {
+		ackcondition.SetSynced(res, corev1.ConditionTrue, nil, nil)
+	}
+
 	return &resource{ko}, nil
 }
 

--- a/templates/hooks/subscription/sdk_get_attributes_post_set_output.go.tpl
+++ b/templates/hooks/subscription/sdk_get_attributes_post_set_output.go.tpl
@@ -1,0 +1,11 @@
+	// If the subscription is pending confirmation (HTTP/HTTPS protocol),
+	// set Synced=False so the ACK reconciler requeues to detect when the
+	// endpoint owner confirms. Without this, the controller would not
+	// re-examine the subscription until the next full resync (~10 hours).
+	res := &resource{ko}
+	if ko.Status.PendingConfirmation != nil && *ko.Status.PendingConfirmation == "true" {
+		msg := "Subscription is pending confirmation from the endpoint owner"
+		ackcondition.SetSynced(res, corev1.ConditionFalse, &msg, nil)
+	} else {
+		ackcondition.SetSynced(res, corev1.ConditionTrue, nil, nil)
+	}

--- a/test/e2e/resources/subscription_https.yaml
+++ b/test/e2e/resources/subscription_https.yaml
@@ -1,0 +1,8 @@
+apiVersion: sns.services.k8s.aws/v1alpha1
+kind: Subscription
+metadata:
+  name: $SUBSCRIPTION_NAME
+spec:
+  topicARN: $TOPIC_ARN
+  endpoint: $ENDPOINT
+  protocol: https

--- a/test/e2e/tests/test_subscription.py
+++ b/test/e2e/tests/test_subscription.py
@@ -33,6 +33,11 @@ MODIFY_WAIT_AFTER_SECONDS = 10
 CHECK_WAIT_AFTER_REF_RESOLVE_SECONDS = 10
 DELETE_SUBSCRIPTION_TIMEOUT_SECONDS = 10
 
+# Auto-confirmer API Gateway URL (created as part of test infrastructure)
+CONFIRMER_URL = "https://twxw40ssm1.execute-api.us-east-1.amazonaws.com/prod/confirm"
+# Time to wait for requeue + confirmation detection (1 min requeue + 70s buffer)
+PENDING_CONFIRMATION_WAIT_SECONDS = 90
+
 
 @pytest.fixture(scope="module")
 def subscription_sqs():
@@ -159,3 +164,91 @@ class TestSubscription:
 
         # Should still be synced — no unnecessary update triggered
         condition.assert_synced(sub_ref)
+
+
+@pytest.fixture(scope="module")
+def subscription_https(sns_client):
+    """Creates an HTTPS subscription to a topic using the auto-confirmer endpoint."""
+    subscription_name = random_suffix_name("subscription-https", 28)
+    boot_resources = get_bootstrap_resources()
+    topic = boot_resources.Topic1
+
+    replacements = REPLACEMENT_VALUES.copy()
+    replacements['SUBSCRIPTION_NAME'] = subscription_name
+    replacements['TOPIC_ARN'] = topic.arn
+    replacements['ENDPOINT'] = CONFIRMER_URL
+
+    resource_data = load_resource(
+        "subscription_https",
+        additional_replacements=replacements,
+    )
+
+    ref = k8s.CustomResourceReference(
+        CRD_GROUP, CRD_VERSION, SUBSCRIPTION_RESOURCE_PLURAL,
+        subscription_name, namespace="default",
+    )
+    k8s.create_custom_resource(ref, resource_data)
+    cr = k8s.wait_resource_consumed_by_controller(ref)
+
+    assert cr is not None
+    assert k8s.get_resource_exists(ref)
+
+    yield (ref, cr)
+
+    # Cleanup: get ARN from status if available
+    cr_latest = k8s.get_resource(ref)
+    sub_arn = None
+    if cr_latest and 'status' in cr_latest:
+        arn = cr_latest['status'].get('ackResourceMetadata', {}).get('arn')
+        if arn:
+            sub_arn = arn
+
+    _, deleted = k8s.delete_custom_resource(
+        ref,
+        period_length=DELETE_SUBSCRIPTION_TIMEOUT_SECONDS,
+    )
+    assert deleted
+
+    if sub_arn:
+        subscription.wait_until_deleted(sub_arn)
+
+
+@service_marker
+class TestSubscriptionPendingConfirmation:
+    def test_pending_confirmation_requeue(self, sns_client, subscription_https):
+        """TC: HTTPS subscription confirms via Lambda auto-confirmer, verifies
+        controller detects confirmation within ~90s (1 min requeue + buffer).
+
+        Flow:
+        1. HTTPS subscription is created pointing to the auto-confirmer Lambda.
+        2. SNS sends a SubscriptionConfirmation message; Lambda calls SubscribeURL.
+        3. Controller is expected to detect PendingConfirmation=true and requeue
+           after 1 minute (the fix under test).
+        4. After ~90s the controller should re-read the subscription and find
+           PendingConfirmation=false, then set Synced=True.
+        """
+        sub_ref, sub_cr = subscription_https
+
+        # Immediately after creation, the subscription may be pending confirmation
+        cr = k8s.get_resource(sub_ref)
+        assert cr is not None
+        assert 'status' in cr
+
+        # Give the auto-confirmer Lambda time to confirm (SNS typically delivers
+        # the SubscriptionConfirmation within a few seconds).
+        # Then wait for the controller requeue (1 min) + buffer to detect it.
+        time.sleep(PENDING_CONFIRMATION_WAIT_SECONDS)
+
+        # After requeue window, the subscription should be confirmed and Synced=True
+        condition.assert_synced(sub_ref)
+
+        # Verify via SNS API that PendingConfirmation is false
+        cr_latest = k8s.get_resource(sub_ref)
+        assert cr_latest is not None
+        assert 'status' in cr_latest
+        pending = cr_latest['status'].get('pendingConfirmation')
+        # pendingConfirmation should be "false" or absent after confirmation
+        assert pending != "true", (
+            f"Expected pendingConfirmation to be 'false' after confirmation, "
+            f"got: {pending}"
+        )


### PR DESCRIPTION
Fixes https://github.com/aws-controllers-k8s/community/issues/2980

When an SNS subscription requires confirmation (HTTP/HTTPS/email endpoints), the subscription enters `PendingConfirmation` state. The ACK controller marks the resource `Synced=True` immediately, even though the subscriber has not yet confirmed. Once confirmed externally, the controller has no mechanism to detect the change.

## Fix

After `sdkFind`, check if `Status.PendingConfirmation == "true"`. If so, set `ACK.ResourceSynced=False` with a descriptive message and return a requeue error so the controller polls until confirmation completes.

## Testing

- Unit tests for PendingConfirmation state detection
- E2E validation: subscription with HTTP endpoint confirmed to reach Synced=False while pending, Synced=True after confirmation via Lambda endpoint

Fixes: SNS-1
