### PR TITLE
Add cross-resource references to PlatformApplication and PlatformEndpoint

### DIFF
--- a/apis/v1alpha1/ack-generate-metadata.yaml
+++ b/apis/v1alpha1/ack-generate-metadata.yaml
@@ -1,13 +1,13 @@
 ack_generate_info:
-  build_date: "2026-08-04T17:35:21Z"
+  build_date: "2026-08-12T00:41:10Z"
   build_hash: db232581a560896c2dc461a244f96d5bf3191ec6
-  go_version: go1.26.5
+  go_version: go1.26.0
   version: v0.62.0
-api_directory_checksum: 3560bd69253be24ef75e5d0b16aa8fc538946d40
+api_directory_checksum: ad2aef754c89476aa5383490bba3ec183f5a2d42
 api_version: v1alpha1
 aws_sdk_go_version: v1.34.0
 generator_config_info:
-  file_checksum: d6057746088e3ced93cefc5c17651a76131108bb
+  file_checksum: 4ea46530b34f4ae28f7d3157fe83972e431f8282
   original_file_name: generator.yaml
 last_modification:
   reason: API generation

--- a/apis/v1alpha1/generator.yaml
+++ b/apis/v1alpha1/generator.yaml
@@ -225,6 +225,10 @@ resources:
           path: Status.ACKResourceMetadata.ARN
       EventDeliveryFailure:
         is_attribute: true
+        type: string
+        references:
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
       SuccessFeedbackRoleArn:
         is_attribute: true
         type: string
@@ -252,6 +256,10 @@ resources:
         is_attribute: true
       Enabled:
         is_attribute: true
+      PlatformApplicationArn:
+        references:
+          resource: PlatformApplication
+          path: Status.ACKResourceMetadata.ARN
       Token:
         is_attribute: true
     tags:

--- a/apis/v1alpha1/platform_application.go
+++ b/apis/v1alpha1/platform_application.go
@@ -25,6 +25,7 @@ import (
 // Platform application object.
 type PlatformApplicationSpec struct {
 	EventDeliveryFailure    *string                                  `json:"eventDeliveryFailure,omitempty"`
+	EventDeliveryFailureRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"eventDeliveryFailureRef,omitempty"`
 	EventEndpointCreated    *string                                  `json:"eventEndpointCreated,omitempty"`
 	EventEndpointCreatedRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"eventEndpointCreatedRef,omitempty"`
 	EventEndpointDeleted    *string                                  `json:"eventEndpointDeleted,omitempty"`

--- a/apis/v1alpha1/platform_endpoint.go
+++ b/apis/v1alpha1/platform_endpoint.go
@@ -29,8 +29,8 @@ type PlatformEndpointSpec struct {
 	Enabled        *string `json:"enabled,omitempty"`
 	// PlatformApplicationArn returned from CreatePlatformApplication is used to
 	// create a an endpoint.
-	// +kubebuilder:validation:Required
-	PlatformApplicationARN *string `json:"platformApplicationARN"`
+	PlatformApplicationARN *string                                  `json:"platformApplicationARN,omitempty"`
+	PlatformApplicationRef *ackv1alpha1.AWSResourceReferenceWrapper `json:"platformApplicationRef,omitempty"`
 	// Unique identifier created by the notification service for an app on a device.
 	// The specific name for Token will vary, depending on which notification service
 	// is being used. For example, when using APNS as the notification service,

--- a/apis/v1alpha1/zz_generated.deepcopy.go
+++ b/apis/v1alpha1/zz_generated.deepcopy.go
@@ -202,6 +202,11 @@ func (in *PlatformApplicationSpec) DeepCopyInto(out *PlatformApplicationSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.EventDeliveryFailureRef != nil {
+		in, out := &in.EventDeliveryFailureRef, &out.EventDeliveryFailureRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
+	}
 	if in.EventEndpointCreated != nil {
 		in, out := &in.EventEndpointCreated, &out.EventEndpointCreated
 		*out = new(string)
@@ -432,6 +437,11 @@ func (in *PlatformEndpointSpec) DeepCopyInto(out *PlatformEndpointSpec) {
 		in, out := &in.PlatformApplicationARN, &out.PlatformApplicationARN
 		*out = new(string)
 		**out = **in
+	}
+	if in.PlatformApplicationRef != nil {
+		in, out := &in.PlatformApplicationRef, &out.PlatformApplicationRef
+		*out = new(corev1alpha1.AWSResourceReferenceWrapper)
+		(*in).DeepCopyInto(*out)
 	}
 	if in.Token != nil {
 		in, out := &in.Token, &out.Token

--- a/config/crd/bases/sns.services.k8s.aws_platformapplications.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_platformapplications.yaml
@@ -45,6 +45,23 @@ spec:
             properties:
               eventDeliveryFailure:
                 type: string
+              eventDeliveryFailureRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               eventEndpointCreated:
                 type: string
               eventEndpointCreatedRef:

--- a/config/crd/bases/sns.services.k8s.aws_platformendpoints.yaml
+++ b/config/crd/bases/sns.services.k8s.aws_platformendpoints.yaml
@@ -51,6 +51,23 @@ spec:
                   PlatformApplicationArn returned from CreatePlatformApplication is used to
                   create a an endpoint.
                 type: string
+              platformApplicationRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               token:
                 description: |-
                   Unique identifier created by the notification service for an app on a device.
@@ -61,7 +78,6 @@ spec:
                   ID.
                 type: string
             required:
-            - platformApplicationARN
             - token
             type: object
           status:

--- a/generator.yaml
+++ b/generator.yaml
@@ -225,6 +225,10 @@ resources:
           path: Status.ACKResourceMetadata.ARN
       EventDeliveryFailure:
         is_attribute: true
+        type: string
+        references:
+          resource: Topic
+          path: Status.ACKResourceMetadata.ARN
       SuccessFeedbackRoleArn:
         is_attribute: true
         type: string
@@ -252,6 +256,10 @@ resources:
         is_attribute: true
       Enabled:
         is_attribute: true
+      PlatformApplicationArn:
+        references:
+          resource: PlatformApplication
+          path: Status.ACKResourceMetadata.ARN
       Token:
         is_attribute: true
     tags:

--- a/helm/crds/sns.services.k8s.aws_platformapplications.yaml
+++ b/helm/crds/sns.services.k8s.aws_platformapplications.yaml
@@ -45,6 +45,23 @@ spec:
             properties:
               eventDeliveryFailure:
                 type: string
+              eventDeliveryFailureRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               eventEndpointCreated:
                 type: string
               eventEndpointCreatedRef:

--- a/helm/crds/sns.services.k8s.aws_platformendpoints.yaml
+++ b/helm/crds/sns.services.k8s.aws_platformendpoints.yaml
@@ -51,6 +51,23 @@ spec:
                   PlatformApplicationArn returned from CreatePlatformApplication is used to
                   create a an endpoint.
                 type: string
+              platformApplicationRef:
+                description: "AWSResourceReferenceWrapper provides a wrapper around
+                  *AWSResourceReference\ntype to provide more user friendly syntax
+                  for references using 'from' field\nEx:\nAPIIDRef:\n\n\tfrom:\n\t
+                  \ name: my-api"
+                properties:
+                  from:
+                    description: |-
+                      AWSResourceReference provides all the values necessary to reference another
+                      k8s resource for finding the identifier(Id/ARN/Name)
+                    properties:
+                      name:
+                        type: string
+                      namespace:
+                        type: string
+                    type: object
+                type: object
               token:
                 description: |-
                   Unique identifier created by the notification service for an app on a device.
@@ -61,7 +78,6 @@ spec:
                   ID.
                 type: string
             required:
-            - platformApplicationARN
             - token
             type: object
           status:

--- a/pkg/resource/platform_application/delta.go
+++ b/pkg/resource/platform_application/delta.go
@@ -49,6 +49,9 @@ func newResourceDelta(
 			delta.Add("Spec.EventDeliveryFailure", a.ko.Spec.EventDeliveryFailure, b.ko.Spec.EventDeliveryFailure)
 		}
 	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.EventDeliveryFailureRef, b.ko.Spec.EventDeliveryFailureRef) {
+		delta.Add("Spec.EventDeliveryFailureRef", a.ko.Spec.EventDeliveryFailureRef, b.ko.Spec.EventDeliveryFailureRef)
+	}
 	if ackcompare.HasNilDifference(a.ko.Spec.EventEndpointCreated, b.ko.Spec.EventEndpointCreated) {
 		delta.Add("Spec.EventEndpointCreated", a.ko.Spec.EventEndpointCreated, b.ko.Spec.EventEndpointCreated)
 	} else if a.ko.Spec.EventEndpointCreated != nil && b.ko.Spec.EventEndpointCreated != nil {

--- a/pkg/resource/platform_application/references.go
+++ b/pkg/resource/platform_application/references.go
@@ -45,6 +45,10 @@ import (
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
 
+	if ko.Spec.EventDeliveryFailureRef != nil {
+		ko.Spec.EventDeliveryFailure = nil
+	}
+
 	if ko.Spec.EventEndpointCreatedRef != nil {
 		ko.Spec.EventEndpointCreated = nil
 	}
@@ -84,6 +88,12 @@ func (rm *resourceManager) ResolveReferences(
 
 	resourceHasReferences := false
 	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForEventDeliveryFailure(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
 	if fieldHasReferences, err := rm.resolveReferenceForEventEndpointCreated(ctx, apiReader, ko); err != nil {
 		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
 	} else {
@@ -121,6 +131,10 @@ func (rm *resourceManager) ResolveReferences(
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.PlatformApplication) error {
 
+	if ko.Spec.EventDeliveryFailureRef != nil && ko.Spec.EventDeliveryFailure != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("EventDeliveryFailure", "EventDeliveryFailureRef")
+	}
+
 	if ko.Spec.EventEndpointCreatedRef != nil && ko.Spec.EventEndpointCreated != nil {
 		return ackerr.ResourceReferenceAndIDNotSupportedFor("EventEndpointCreated", "EventEndpointCreatedRef")
 	}
@@ -143,20 +157,20 @@ func validateReferenceFields(ko *svcapitypes.PlatformApplication) error {
 	return nil
 }
 
-// resolveReferenceForEventEndpointCreated reads the resource referenced
-// from EventEndpointCreatedRef field and sets the EventEndpointCreated
+// resolveReferenceForEventDeliveryFailure reads the resource referenced
+// from EventDeliveryFailureRef field and sets the EventDeliveryFailure
 // from referenced resource. Returns a boolean indicating whether a reference
 // contains references, or an error
-func (rm *resourceManager) resolveReferenceForEventEndpointCreated(
+func (rm *resourceManager) resolveReferenceForEventDeliveryFailure(
 	ctx context.Context,
 	apiReader client.Reader,
 	ko *svcapitypes.PlatformApplication,
 ) (hasReferences bool, err error) {
-	if ko.Spec.EventEndpointCreatedRef != nil && ko.Spec.EventEndpointCreatedRef.From != nil {
+	if ko.Spec.EventDeliveryFailureRef != nil && ko.Spec.EventDeliveryFailureRef.From != nil {
 		hasReferences = true
-		arr := ko.Spec.EventEndpointCreatedRef.From
+		arr := ko.Spec.EventDeliveryFailureRef.From
 		if arr.Name == nil || *arr.Name == "" {
-			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: EventEndpointCreatedRef")
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: EventDeliveryFailureRef")
 		}
 		namespace, err := ackrt.ResolveCrossNamespaceReference(
 			ctx,
@@ -174,7 +188,7 @@ func (rm *resourceManager) resolveReferenceForEventEndpointCreated(
 		if err := getReferencedResourceState_Topic(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
 			return hasReferences, err
 		}
-		ko.Spec.EventEndpointCreated = (*string)(obj.Status.ACKResourceMetadata.ARN)
+		ko.Spec.EventDeliveryFailure = (*string)(obj.Status.ACKResourceMetadata.ARN)
 	}
 
 	return hasReferences, nil
@@ -232,6 +246,43 @@ func getReferencedResourceState_Topic(
 			"Status.ACKResourceMetadata.ARN")
 	}
 	return nil
+}
+
+// resolveReferenceForEventEndpointCreated reads the resource referenced
+// from EventEndpointCreatedRef field and sets the EventEndpointCreated
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForEventEndpointCreated(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.PlatformApplication,
+) (hasReferences bool, err error) {
+	if ko.Spec.EventEndpointCreatedRef != nil && ko.Spec.EventEndpointCreatedRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.EventEndpointCreatedRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: EventEndpointCreatedRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.Topic{}
+		if err := getReferencedResourceState_Topic(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.EventEndpointCreated = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
 }
 
 // resolveReferenceForEventEndpointDeleted reads the resource referenced

--- a/pkg/resource/platform_endpoint/delta.go
+++ b/pkg/resource/platform_endpoint/delta.go
@@ -20,6 +20,7 @@ import (
 
 	ackcompare "github.com/aws-controllers-k8s/runtime/pkg/compare"
 	acktags "github.com/aws-controllers-k8s/runtime/pkg/tags"
+	"k8s.io/apimachinery/pkg/api/equality"
 )
 
 // Hack to avoid import errors during build...
@@ -61,6 +62,9 @@ func newResourceDelta(
 		if *a.ko.Spec.PlatformApplicationARN != *b.ko.Spec.PlatformApplicationARN {
 			delta.Add("Spec.PlatformApplicationARN", a.ko.Spec.PlatformApplicationARN, b.ko.Spec.PlatformApplicationARN)
 		}
+	}
+	if !equality.Semantic.Equalities.DeepEqual(a.ko.Spec.PlatformApplicationRef, b.ko.Spec.PlatformApplicationRef) {
+		delta.Add("Spec.PlatformApplicationRef", a.ko.Spec.PlatformApplicationRef, b.ko.Spec.PlatformApplicationRef)
 	}
 	if ackcompare.HasNilDifference(a.ko.Spec.Token, b.ko.Spec.Token) {
 		delta.Add("Spec.Token", a.ko.Spec.Token, b.ko.Spec.Token)

--- a/pkg/resource/platform_endpoint/references.go
+++ b/pkg/resource/platform_endpoint/references.go
@@ -17,9 +17,15 @@ package platform_endpoint
 
 import (
 	"context"
+	"fmt"
 
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	ackv1alpha1 "github.com/aws-controllers-k8s/runtime/apis/core/v1alpha1"
+	ackerr "github.com/aws-controllers-k8s/runtime/pkg/errors"
+	ackrt "github.com/aws-controllers-k8s/runtime/pkg/runtime"
 	acktypes "github.com/aws-controllers-k8s/runtime/pkg/types"
 
 	svcapitypes "github.com/aws-controllers-k8s/sns-controller/apis/v1alpha1"
@@ -31,6 +37,10 @@ import (
 // values.
 func (rm *resourceManager) ClearResolvedReferences(res acktypes.AWSResource) acktypes.AWSResource {
 	ko := rm.concreteResource(res).ko.DeepCopy()
+
+	if ko.Spec.PlatformApplicationRef != nil {
+		ko.Spec.PlatformApplicationARN = nil
+	}
 
 	return &resource{ko}
 }
@@ -47,11 +57,119 @@ func (rm *resourceManager) ResolveReferences(
 	apiReader client.Reader,
 	res acktypes.AWSResource,
 ) (acktypes.AWSResource, bool, error) {
-	return res, false, nil
+	ko := rm.concreteResource(res).ko
+
+	resourceHasReferences := false
+	err := validateReferenceFields(ko)
+	if fieldHasReferences, err := rm.resolveReferenceForPlatformApplicationARN(ctx, apiReader, ko); err != nil {
+		return &resource{ko}, (resourceHasReferences || fieldHasReferences), err
+	} else {
+		resourceHasReferences = resourceHasReferences || fieldHasReferences
+	}
+
+	return &resource{ko}, resourceHasReferences, err
 }
 
 // validateReferenceFields validates the reference field and corresponding
 // identifier field.
 func validateReferenceFields(ko *svcapitypes.PlatformEndpoint) error {
+
+	if ko.Spec.PlatformApplicationRef != nil && ko.Spec.PlatformApplicationARN != nil {
+		return ackerr.ResourceReferenceAndIDNotSupportedFor("PlatformApplicationARN", "PlatformApplicationRef")
+	}
+	if ko.Spec.PlatformApplicationRef == nil && ko.Spec.PlatformApplicationARN == nil {
+		return ackerr.ResourceReferenceOrIDRequiredFor("PlatformApplicationARN", "PlatformApplicationRef")
+	}
+	return nil
+}
+
+// resolveReferenceForPlatformApplicationARN reads the resource referenced
+// from PlatformApplicationRef field and sets the PlatformApplicationARN
+// from referenced resource. Returns a boolean indicating whether a reference
+// contains references, or an error
+func (rm *resourceManager) resolveReferenceForPlatformApplicationARN(
+	ctx context.Context,
+	apiReader client.Reader,
+	ko *svcapitypes.PlatformEndpoint,
+) (hasReferences bool, err error) {
+	if ko.Spec.PlatformApplicationRef != nil && ko.Spec.PlatformApplicationRef.From != nil {
+		hasReferences = true
+		arr := ko.Spec.PlatformApplicationRef.From
+		if arr.Name == nil || *arr.Name == "" {
+			return hasReferences, fmt.Errorf("provided resource reference is nil or empty: PlatformApplicationRef")
+		}
+		namespace, err := ackrt.ResolveCrossNamespaceReference(
+			ctx,
+			rm.cfg.EnableCrossNamespace,
+			&ko.Status.Conditions,
+			ackrt.CrossNamespaceRefKindResource,
+			ko.ObjectMeta.GetNamespace(),
+			arr.Namespace,
+			*arr.Name,
+		)
+		if err != nil {
+			return hasReferences, err
+		}
+		obj := &svcapitypes.PlatformApplication{}
+		if err := getReferencedResourceState_PlatformApplication(ctx, apiReader, obj, *arr.Name, namespace); err != nil {
+			return hasReferences, err
+		}
+		ko.Spec.PlatformApplicationARN = (*string)(obj.Status.ACKResourceMetadata.ARN)
+	}
+
+	return hasReferences, nil
+}
+
+// getReferencedResourceState_PlatformApplication looks up whether a referenced resource
+// exists and is in a ACK.ResourceSynced=True state. If the referenced resource does exist and is
+// in a Synced state, returns nil, otherwise returns `ackerr.ResourceReferenceTerminalFor` or
+// `ResourceReferenceNotSyncedFor` depending on if the resource is in a Terminal state.
+func getReferencedResourceState_PlatformApplication(
+	ctx context.Context,
+	apiReader client.Reader,
+	obj *svcapitypes.PlatformApplication,
+	name string, // the Kubernetes name of the referenced resource
+	namespace string, // the Kubernetes namespace of the referenced resource
+) error {
+	namespacedName := types.NamespacedName{
+		Namespace: namespace,
+		Name:      name,
+	}
+	err := apiReader.Get(ctx, namespacedName, obj)
+	if err != nil {
+		return err
+	}
+	var refResourceTerminal bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeTerminal &&
+			cond.Status == corev1.ConditionTrue {
+			return ackerr.ResourceReferenceTerminalFor(
+				"PlatformApplication",
+				namespace, name)
+		}
+	}
+	if refResourceTerminal {
+		return ackerr.ResourceReferenceTerminalFor(
+			"PlatformApplication",
+			namespace, name)
+	}
+	var refResourceSynced bool
+	for _, cond := range obj.Status.Conditions {
+		if cond.Type == ackv1alpha1.ConditionTypeResourceSynced &&
+			cond.Status == corev1.ConditionTrue {
+			refResourceSynced = true
+		}
+	}
+	if !refResourceSynced {
+		return ackerr.ResourceReferenceNotSyncedFor(
+			"PlatformApplication",
+			namespace, name)
+	}
+	if obj.Status.ACKResourceMetadata == nil || obj.Status.ACKResourceMetadata.ARN == nil {
+		return ackerr.ResourceReferenceMissingTargetFieldFor(
+			"PlatformApplication",
+			namespace, name,
+			"Status.ACKResourceMetadata.ARN")
+	}
 	return nil
 }

--- a/test/e2e/requirements.txt
+++ b/test/e2e/requirements.txt
@@ -1,1 +1,1 @@
-acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@38ce32256cc2552ab54e190cc8a8618e93af9e0c
+acktest @ git+https://github.com/aws-controllers-k8s/test-infra.git@e87315b032dfb8e0322ae5a1c90c0e15ea2bf5ff


### PR DESCRIPTION
Adds cross-resource references to 2 fields across 2 resources in `sns-controller`, from a cross-resource reference audit of the controller.

Both targets are same-service, so `service_name` is omitted, no module dependency is added (`go.mod` is unchanged) and `ATTRIBUTION.md` needs no regeneration.

### Fields Added

| # | Field (`generator.yaml` path) | Target | `path` |
| --- | --- | --- | --- |
| 1 | `PlatformApplication.EventDeliveryFailure` | sns `Topic` (same service) | `Status.ACKResourceMetadata.ARN` |
| 2 | `PlatformEndpoint.PlatformApplicationArn` | sns `PlatformApplication` (same service) | `Status.ACKResourceMetadata.ARN` |

**1 — `PlatformApplication.EventDeliveryFailure`.** The attributes documentation on `SetPlatformApplicationAttributesInput.Attributes` describes it as a "Topic ARN to which DeliveryFailure event notifications are sent". It is the fourth member of a four-member family of topic ARN attributes, and the only one that was unwired: `EventEndpointCreated`, `EventEndpointDeleted` and `EventEndpointUpdated` already reference `Topic` at this exact path. `type: string` is set alongside the `references` block to match those three siblings — attribute-map fields have no Smithy member to infer a type from.

**2 — `PlatformEndpoint.PlatformApplicationArn`.** The parent platform application's ARN, and `required` on `CreatePlatformEndpoint`. This is the more consequential of the two: `PlatformEndpoint` had no references at all, so an endpoint could not be declared in the same manifest as the application it belongs to. Regeneration correctly drops the field from the CRD's `required` list, which is what makes a manifest supplying only `platformApplicationRef` valid.

`Status.ACKResourceMetadata.ARN` is canonical for both targets: `Topic` and `PlatformApplication` each set `is_arn_primary_key: true`, and the attributes maps echo the full ARN back, so ARN compares against ARN with no form mismatch.

Neither field is nested, so neither needs `set: ignore` or `late_initialize`.

### One audited gap deliberately not wired

The same audit reported `Subscription.Endpoint` → sqs `Queue` as a third gap. It is **not** included here because it is polymorphic. `SubscribeInput.Endpoint` targets shape `Endpoint2`, a bare `string` with no `pattern`, and its documentation enumerates nine protocol branches of which four are distinct AWS resource types — sqs `Queue`, lambda `Function`, firehose `DeliveryStream`, and sns `PlatformEndpoint` — selected by the sibling `protocol` field.

A `references` block names exactly one `resource` and the generated resolver instantiates one concrete Kind, so wiring `sqs Queue` would privilege one arm of the union invisibly: the `*Ref` companion is named for the field, not the target, so nothing would tell a user on `protocol: lambda` that the companion is not for them. The concrete field already accepts every protocol's value, so leaving it alone costs users nothing they have today.

### Verification

Deployed this branch to `ack-dev-auto` (`us-west-2`) with a 60s resync period (`ack-workspace deploy sns --resync-period 60`) and tested both fields. PASS requires all four conditions, held delta-free across at least 3 reconciles: `ACK.ReferencesResolved=True`, `ACK.ResourceSynced=True`, concrete field absent from `.spec`, `*Ref` present in `.spec` with the expected target.

| # | Resource.field | RefsResolved | Synced | Concrete absent | `*Ref` present | Deltas / 3+ resyncs | Result |
| --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | `PlatformApplication.eventDeliveryFailureRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |
| 2 | `PlatformEndpoint.platformApplicationRef` | ✅ | ✅ | ✅ | ✅ | 0 | **PASS** |

**Summary: 2/2 PASS** — resync period 60s, delta-free across 5 reconciles (5 ≥ 3).

Resolution was also confirmed on the AWS side rather than only from the conditions: `GetPlatformApplicationAttributes` returned the resolved topic ARN as the `EventDeliveryFailure` attribute, and the endpoint was created under `app/MPNS/ref-test-app`, which is only reachable if the resolved application ARN was the one sent.

<details>
<summary>Test manifests</summary>

```yaml
apiVersion: sns.services.k8s.aws/v1alpha1
kind: Topic
metadata:
  name: ref-test-topic
  namespace: default
spec:
  name: ref-test-topic
---
apiVersion: sns.services.k8s.aws/v1alpha1
kind: PlatformApplication
metadata:
  name: ref-test-app
  namespace: default
spec:
  name: ref-test-app
  # MPNS only because SNS does not validate its credentials with a third party,
  # so the resource can actually reach ResourceSynced=True. GCM/APNS/ADM are all
  # rejected with "Platform credentials are invalid" without real credentials.
  # The reference under test is platform-independent.
  platform: MPNS
  platformCredential: dummy-credential-value
  platformPrincipal: dummy-principal-value
  # field 1 under test; concrete eventDeliveryFailure deliberately omitted
  eventDeliveryFailureRef:
    from:
      name: ref-test-topic
---
apiVersion: sns.services.k8s.aws/v1alpha1
kind: PlatformEndpoint
metadata:
  name: ref-test-endpoint
  namespace: default
spec:
  token: http://sn1.notify.live.net/throttledthirdparty/01.00/AQFsAJDVLQtNRuiaTOA6bAV9
  # field 2 under test; concrete platformApplicationARN deliberately omitted.
  # Before this change that was impossible, the field was in the CRD required list.
  platformApplicationRef:
    from:
      name: ref-test-app
```

</details>

<details>
<summary>Observed state</summary>

Field 1 — `PlatformApplication.eventDeliveryFailureRef`, after ~8 minutes and many reconciles:

```
$ kubectl -n default get platformapplication ref-test-app -o json | jq '{...}'
{
  "c1_ReferencesResolved": "True",
  "c2_ResourceSynced": "True",
  "c3_concrete_absent": true,
  "c4_ref_present": "ref-test-topic"
}
```

Field 2 — `PlatformEndpoint.platformApplicationRef`:

```
$ kubectl -n default get platformendpoint ref-test-endpoint -o json | jq '{spec, conditions, endpointARN}'
{
  "spec": {
    "platformApplicationRef": {
      "from": {
        "name": "ref-test-app"
      }
    },
    "token": "http://sn1.notify.live.net/throttledthirdparty/01.00/AQFsAJDVLQtNRuiaTOA6bAV9"
  },
  "conditions": [
    { "type": "ACK.ReferencesResolved", "status": "True",  "message": null },
    { "type": "ACK.ResourceSynced",     "status": "True",  "message": "Resource synced successfully" },
    { "type": "Ready",                  "status": "True",  "message": "Resource synced successfully" }
  ],
  "endpointARN": "arn:aws:sns:us-west-2:...:endpoint/MPNS/ref-test-app/6fb9b1d7-3658-3710-8a15-3d0a68644e21"
}
```

AWS-side confirmation that the resolved ARN was actually sent and applied:

```
$ aws sns get-platform-application-attributes \
    --platform-application-arn arn:aws:sns:us-west-2:...:app/MPNS/ref-test-app | jq '.Attributes.EventDeliveryFailure'
"arn:aws:sns:us-west-2:...:ref-test-topic"
```

CRD `required` list relaxation for field 2:

```
$ kubectl get crd platformendpoints.sns.services.k8s.aws \
    -o jsonpath='{.spec.versions[0].schema.openAPIV3Schema.properties.spec.required}'
["token"]          # was ["platformApplicationARN","token"]
```

</details>

<details>
<summary>Input variant coverage, and the two pre-existing deltas seen during testing</summary>

Both input variants were covered per field: `*Ref` supplied with the concrete field omitted (the rows above), and the concrete value supplied with no ref (control resources `ctl-test-app` / `ctl-test-endpoint`). The concrete-only path syncs unchanged and, as expected, carries no `ACK.ReferencesResolved` condition at all.

Two recurring deltas did appear in the window, on **neither** of the fields in this PR:

```
$ kubectl -n ack-system logs <pod> --since=10m \
    | grep 'desired resource state has changed' | jq -r '.diff[].Path.Parts|join(".")' | sort | uniq -c
      5 Spec.Enabled
      6 Spec.PlatformCredential
      6 Spec.PlatformPrincipal
```

Zero delta lines named `EventDeliveryFailure`, `EventDeliveryFailureRef`, `PlatformApplicationARN` or `PlatformApplicationRef`.

Both are pre-existing and independent of this change, which the control resources demonstrate — they use no references at all and reproduce the identical paths at the same rate (`ctl-test-app`: `PlatformCredential`/`PlatformPrincipal` ×4; `ctl-test-endpoint`: `Spec.Enabled` ×4). Their causes are visible in the diffs:

- `PlatformCredential` / `PlatformPrincipal` — write-only secrets that `GetPlatformApplicationAttributes` never echoes back, so desired (`A`) always differs from observed (`B: null`). Affects any `PlatformApplication` with credentials.
- `Spec.Enabled` — a server-side default (`A: null` vs `B: "true"`) read back by `sdkFind` but never captured into the spec, i.e. a missing `late_initialize`.

Both look worth a separate fix; I did not address them here to keep this PR to the reference change.

</details>

### Checklist

- [x] Workspace refreshed (runtime, code-generator, controller) before generating
- [x] `service_name` omitted for same-service targets, set for cross-service (both are same-service)
- [x] `path` matches the form the resource's Describe response returns
- [x] Regenerated with `ack-workspace build sns`; controller compiles
- [x] Generated artifacts committed (`apis/`, `pkg/resource/`, `config/crd/`, `helm/`)
- [x] `go.mod` updated and pinned (cross-service only — N/A, unchanged)
- [x] `ATTRIBUTION.md` regenerated (cross-service only — N/A, no new dependency)
- [x] All fields verified against the four pass criteria, delta-free across ≥3 reconciles

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
